### PR TITLE
Account for string/number values for PadSchema's `number` and PinShapeOutputSchema's pinNumber props

### DIFF
--- a/lib/convert-to-typescript-component/index.tsx
+++ b/lib/convert-to-typescript-component/index.tsx
@@ -50,11 +50,11 @@ export const convertToTypescriptComponent = async ({
   const schPinArrangement = {
     leftSide: {
       direction: "top-to-bottom" as const,
-      pins: leftPins.map((pin) => pin.pinNumber),
+      pins: leftPins.map((pin) => pin.pinNumber) as number[],
     },
     rightSide: {
       direction: "bottom-to-top" as const,
-      pins: rightPins.map((pin) => pin.pinNumber).reverse(),
+      pins: rightPins.map((pin) => pin.pinNumber).reverse() as number[],
     },
   }
 

--- a/lib/schemas/package-detail-shape-schema.ts
+++ b/lib/schemas/package-detail-shape-schema.ts
@@ -51,7 +51,7 @@ export const PadSchema = BaseShapeSchema.extend({
   height: tenthmil,
   layermask: z.number(),
   net: z.union([z.string(), z.number()]).optional(),
-  number: z.number(),
+  number: z.union([z.string(), z.number()]),
   holeRadius: tenthmil,
   points: z.array(PointSchema).optional(),
   rotation: z.number().optional(),

--- a/lib/schemas/single-letter-shape-schema.ts
+++ b/lib/schemas/single-letter-shape-schema.ts
@@ -136,7 +136,7 @@ export const EllipseShapeSchema = z
 const PinShapeOutputSchema = z.object({
   type: z.literal("PIN"),
   visibility: z.enum(["show", "hide"]),
-  pinNumber: z.number(),
+  pinNumber: z.union([z.string(), z.number()]),
   x: z.number(),
   y: z.number(),
   rotation: z.number(),
@@ -167,7 +167,7 @@ const parsePin = (pinString: string): z.infer<typeof PinShapeOutputSchema> => {
     type: "PIN",
     visibility: visibility as "show" | "hide",
     id,
-    pinNumber: parseInt(pinNumber),
+    pinNumber: isNaN(Number(pinNumber)) ? pinNumber : Number(pinNumber),
     x: parseFloat(x),
     y: parseFloat(y),
     rotation: parseFloat(rotation),


### PR DESCRIPTION
Closes https://github.com/tscircuit/easyeda-converter/issues/47