### PR TITLE
Add via support for TSX conversion

### DIFF
--- a/lib/websafe/generate-footprint-tsx.ts
+++ b/lib/websafe/generate-footprint-tsx.ts
@@ -8,6 +8,7 @@ export const generateFootprintTsx = (
   const holes = su(circuitJson).pcb_hole.list()
   const platedHoles = su(circuitJson).pcb_plated_hole.list()
   const smtPads = su(circuitJson).pcb_smtpad.list()
+  const vias = su(circuitJson).pcb_via.list()
   const silkscreenPaths = su(circuitJson).pcb_silkscreen_path.list()
   const silkscreenTexts = su(circuitJson).pcb_silkscreen_text.list()
 
@@ -45,6 +46,12 @@ export const generateFootprintTsx = (
         `<smtpad portHints={${JSON.stringify(smtPad.port_hints)}} pcbX="${mmStr(smtPad.x)}" pcbY="${mmStr(smtPad.y)}" width="${mmStr(smtPad.width)}" height="${mmStr(smtPad.height)}" shape="rect" />`,
       )
     }
+  }
+
+  for (const via of vias) {
+    elementStrings.push(
+      `<via pcbX="${mmStr(via.x)}" pcbY="${mmStr(via.y)}" outerDiameter="${mmStr(via.outer_diameter)}" holeDiameter="${mmStr(via.hole_diameter)}" layers={${JSON.stringify(via.layers)}} />`,
+    )
   }
 
   for (const silkscreenPath of silkscreenPaths) {

--- a/tests/convert-to-ts/C46497-to-ts.test.ts
+++ b/tests/convert-to-ts/C46497-to-ts.test.ts
@@ -1,0 +1,15 @@
+import { it, expect } from "bun:test"
+import chipRawEasy from "../assets/C46497.raweasy.json"
+import { convertBetterEasyToTsx } from "lib/websafe/convert-to-typescript-component"
+import { EasyEdaJsonSchema } from "lib/schemas/easy-eda-json-schema"
+
+it("should convert C46497 with vias into typescript file", async () => {
+  const betterEasy = EasyEdaJsonSchema.parse(chipRawEasy)
+  const result = await convertBetterEasyToTsx({
+    betterEasy,
+  })
+
+  expect(result).not.toContain("milmm")
+  expect(result).not.toContain("NaNmm")
+  expect(result).toContain("<via")
+})


### PR DESCRIPTION
## Summary
- support converting vias to TSX in `generateFootprintTsx`
- test converting a component with vias (C46497)

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/convert-to-ts/C46497-to-ts.test.ts`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/convert-to-ts`

------
https://chatgpt.com/codex/tasks/task_b_6861c9f748dc832e8a370a0c63789390