### PR TITLE
Fix debug require issue for Vercel by avoiding bundling node deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "bun test",
     "cli": "bun cli/main.ts",
     "build": "bun build:lib && bun build:cli && bun build:web",
-    "build:lib": "tsup lib/index.ts --platform node --format esm --dts --sourcemap",
+    "build:lib": "tsup-node lib/index.ts --platform node --format esm --dts --sourcemap",
     "build:cli": "tsup cli/main.ts --platform node --format cjs --dts --sourcemap",
     "build:web": "tsup lib/websafe/index.ts --platform browser --format esm --dts --sourcemap -d dist/browser",
     "aider": "aider",


### PR DESCRIPTION
## Summary
- switch build scripts to `tsup-node` to skip node modules bundling
- use regular `tsup` for CLI build so bundling still happens for the CLI output

## Testing
- `bun test`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_686aa8c18820832e87542caf45882458