### PR TITLE
Normalize pin label suffix

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,3 +4,4 @@ export { convertRawEasyToTsx as convertRawEasyEdaToTs } from "./websafe/convert-
 export { normalizeManufacturerPartNumber } from "./utils/normalize-manufacturer-part-number"
 export * from "./schemas/easy-eda-json-schema"
 export { convertEasyEdaJsonToVariousFormats } from "./convert-easyeda-json-to-various-formats"
+export { normalizePinLabels } from "@tscircuit/core"

--- a/lib/schemas/single-letter-shape-schema.ts
+++ b/lib/schemas/single-letter-shape-schema.ts
@@ -194,8 +194,10 @@ const parsePin = (pinString: string): z.infer<typeof PinShapeOutputSchema> => {
   const parts = pinString.split("~")
   const [, visibility, , pinNumber, x, y, rotation, id] = parts
 
-  const nameMatch = pinString.match(/~(\w+)~(start|end)~/)
-  const label = nameMatch ? nameMatch[1] : ""
+  const nameMatch = pinString.match(/~([\w+-]+)~(start|end)~/)
+  let label = nameMatch ? nameMatch[1] : ""
+  if (label.endsWith("+")) label = label.slice(0, -1) + "_POS"
+  if (label.endsWith("-")) label = label.slice(0, -1) + "_NEG"
 
   const colorMatch = pinString.match(/#[0-9A-F]{6}/)
   const labelColor = colorMatch ? colorMatch[0] : ""

--- a/lib/schemas/single-letter-shape-schema.ts
+++ b/lib/schemas/single-letter-shape-schema.ts
@@ -198,6 +198,7 @@ const parsePin = (pinString: string): z.infer<typeof PinShapeOutputSchema> => {
   let label = nameMatch ? nameMatch[1] : ""
   if (label.endsWith("+")) label = label.slice(0, -1) + "_POS"
   if (label.endsWith("-")) label = label.slice(0, -1) + "_NEG"
+  if (/^\+\d+(?:\.\d+)?V$/i.test(label)) label = `V${label.slice(1, -1)}`
 
   const colorMatch = pinString.match(/#[0-9A-F]{6}/)
   const labelColor = colorMatch ? colorMatch[0] : ""

--- a/tests/convert-to-ts/C2886621-to-ts.test.ts
+++ b/tests/convert-to-ts/C2886621-to-ts.test.ts
@@ -21,7 +21,7 @@ it("should convert C2886621 into typescript file", async () => {
 
     const pinLabels = {
       pin1: ["TRIOUT"],
-      pin2: ["pin2"],
+      pin2: ["SINEIN_POS"],
       pin3: ["pin3"],
       pin4: ["AUX1IN"],
       pin5: ["AUX2IN"],
@@ -46,12 +46,12 @@ it("should convert C2886621 into typescript file", async () => {
       pin24: ["SINEOUT"],
       pin25: ["MIXOUT"],
       pin26: ["BWCOMP"],
-      pin27: ["pin27"],
+      pin27: ["V_POS"],
       pin28: ["SQUAREOUT"],
       pin29: ["SAWOUT"],
       pin30: ["PULSEOUT"],
       pin31: ["pin31"],
-      pin32: ["pin32"],
+      pin32: ["PWMIN_POS"],
       pin33: ["EP"]
     } as const
 

--- a/tests/convert-to-ts/C9900017879-to-ts.test.ts
+++ b/tests/convert-to-ts/C9900017879-to-ts.test.ts
@@ -46,7 +46,7 @@ it("should convert C9900017879 into typescript file", async () => {
       pin24: ["A5"],
       pin25: ["A6"],
       pin26: ["A7"],
-      pin27: ["+5V"],
+      pin27: ["V5"],
       pin28: ["RESET2"],
       pin29: ["GND1"],
       pin30: ["VIN"]

--- a/tests/convert-to-ts/C9900017879-to-ts.test.ts
+++ b/tests/convert-to-ts/C9900017879-to-ts.test.ts
@@ -46,7 +46,7 @@ it("should convert C9900017879 into typescript file", async () => {
       pin24: ["A5"],
       pin25: ["A6"],
       pin26: ["A7"],
-      pin27: ["pin27"],
+      pin27: ["+5V"],
       pin28: ["RESET2"],
       pin29: ["GND1"],
       pin30: ["VIN"]

--- a/tests/normalize-pin-labels.test.ts
+++ b/tests/normalize-pin-labels.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { normalizePinLabels } from "@tscircuit/core"
+import { normalizePinLabels } from "lib"
 
 describe("normalizePinLabels", () => {
   test("handles the documentation example correctly", () => {

--- a/tests/parse-tests/pin-label-plus-minus.test.ts
+++ b/tests/parse-tests/pin-label-plus-minus.test.ts
@@ -1,0 +1,14 @@
+import { it, expect } from "bun:test"
+import { PinShapeSchema } from "lib/schemas/single-letter-shape-schema"
+
+const plusPinStr =
+  "P~show~0~1~355~285~180~gge5~0^^355~285^^M355,285h10~#000000^^1~368.7~289~0~C1+~start~~~#000000^^1~364.5~284~0~1~end~~~#000000^^0~362~285^^0~M 365 288 L 368 285 L 365 282"
+const minusPinStr =
+  "P~show~0~2~355~295~180~gge6~0^^355~295^^M355,295h10~#880000^^1~368.7~299~0~C2-~start~~~#0000FF^^1~364.5~294~0~2~end~~~#0000FF^^0~362~295^^0~M 365 298 L 368 295 L 365 292"
+
+it("converts trailing plus and minus in pin labels", () => {
+  const plusPin = PinShapeSchema.parse(plusPinStr)
+  const minusPin = PinShapeSchema.parse(minusPinStr)
+  expect(plusPin.label).toBe("C1_POS")
+  expect(minusPin.label).toBe("C2_NEG")
+})

--- a/tests/parse-tests/pin-label-plus-minus.test.ts
+++ b/tests/parse-tests/pin-label-plus-minus.test.ts
@@ -5,10 +5,17 @@ const plusPinStr =
   "P~show~0~1~355~285~180~gge5~0^^355~285^^M355,285h10~#000000^^1~368.7~289~0~C1+~start~~~#000000^^1~364.5~284~0~1~end~~~#000000^^0~362~285^^0~M 365 288 L 368 285 L 365 282"
 const minusPinStr =
   "P~show~0~2~355~295~180~gge6~0^^355~295^^M355,295h10~#880000^^1~368.7~299~0~C2-~start~~~#0000FF^^1~364.5~294~0~2~end~~~#0000FF^^0~362~295^^0~M 365 298 L 368 295 L 365 292"
+const voltagePinStr =
+  "P~show~0~27~450~260~0~gge31~0^^450~260^^M450,260h-10~#880000^^1~436.3~264~0~+5V~end~~~#0000FF^^1~440.5~259~0~27~start~~~#0000FF^^0~443~260^^0~M 440 257 L 437 260 L 440 263"
 
 it("converts trailing plus and minus in pin labels", () => {
   const plusPin = PinShapeSchema.parse(plusPinStr)
   const minusPin = PinShapeSchema.parse(minusPinStr)
   expect(plusPin.label).toBe("C1_POS")
   expect(minusPin.label).toBe("C2_NEG")
+})
+
+it("normalizes voltage pin labels with leading plus", () => {
+  const pin = PinShapeSchema.parse(voltagePinStr)
+  expect(pin.label).toBe("V5")
 })


### PR DESCRIPTION
## Summary
- implement conversion of plus/minus pin label suffixes inside `PinShapeSchema`
- re-export `normalizePinLabels` from `@tscircuit/core`
- update conversions and tests to reflect new normalization behavior
- add test for parsing pin labels with + and - suffixes

## Testing
- `bun run format`
- `bun test -u`

------
https://chatgpt.com/codex/tasks/task_b_686fde235c78832c8778df9ea9f937a8