### PR TITLE
Convert diode-category EasyEDA parts to tscircuit diodes

### DIFF
--- a/lib/schemas/easy-eda-json-schema.ts
+++ b/lib/schemas/easy-eda-json-schema.ts
@@ -160,6 +160,7 @@ export const EasyEdaJsonSchema = z.object({
   lcsc: LcscSchema,
   owner: OwnerSchema,
   tags: z.array(z.string()),
+  category: z.string().optional(),
   updateTime: z.number(),
   updated_at: z.string(),
   dataStr: DataStrSchema,

--- a/lib/websafe/convert-to-typescript-component/category-value-contains-diode.ts
+++ b/lib/websafe/convert-to-typescript-component/category-value-contains-diode.ts
@@ -1,0 +1,15 @@
+export const categoryValueContainsDiode = (value: unknown): boolean => {
+  if (typeof value === "string") {
+    return /(^|[^a-z])diodes?([^a-z]|$)/i.test(value)
+  }
+
+  if (Array.isArray(value)) {
+    return value.some(categoryValueContainsDiode)
+  }
+
+  if (value && typeof value === "object") {
+    return Object.values(value).some(categoryValueContainsDiode)
+  }
+
+  return false
+}

--- a/lib/websafe/convert-to-typescript-component/generate-typescript-component.ts
+++ b/lib/websafe/convert-to-typescript-component/generate-typescript-component.ts
@@ -1,6 +1,8 @@
-import type { ChipProps } from "@tscircuit/props"
+import type { ChipProps, SupplierPartNumbers } from "@tscircuit/props"
 import type { AnyCircuitElement } from "circuit-json"
 import { generateFootprintTsx } from "../generate-footprint-tsx"
+
+export type GeneratedComponentType = "chip" | "diode"
 
 interface Params {
   pinLabels: ChipProps["pinLabels"]
@@ -8,8 +10,37 @@ interface Params {
   objUrl?: string
   stepUrl?: string
   circuitJson: AnyCircuitElement[]
-  supplierPartNumbers: ChipProps["supplierPartNumbers"]
+  supplierPartNumbers: SupplierPartNumbers
   manufacturerPartNumber: string
+  componentType?: GeneratedComponentType
+}
+
+const getPinLabelValues = (labels: string | readonly string[]): string[] => {
+  if (typeof labels === "string") return [labels]
+  return [...labels]
+}
+
+const getDiodePortHintsMap = (
+  pinLabels: ChipProps["pinLabels"],
+): Record<string, string[]> | undefined => {
+  const labelsByPin = Object.entries(pinLabels ?? {}).map(([pin, labels]) => ({
+    pin,
+    labels: getPinLabelValues(labels).map((label) => label.toLowerCase()),
+  }))
+
+  const anodePin = labelsByPin.find(({ labels }) =>
+    labels.some((label) => ["a", "anode", "pos", "+"].includes(label)),
+  )?.pin
+  const cathodePin = labelsByPin.find(({ labels }) =>
+    labels.some((label) => ["c", "k", "cathode", "neg", "-"].includes(label)),
+  )?.pin
+
+  if (!anodePin || !cathodePin) return undefined
+
+  return {
+    [anodePin]: ["pin1", "anode"],
+    [cathodePin]: ["pin2", "cathode"],
+  }
 }
 
 export const generateTypescriptComponent = ({
@@ -20,11 +51,17 @@ export const generateTypescriptComponent = ({
   circuitJson,
   supplierPartNumbers,
   manufacturerPartNumber,
+  componentType = "chip",
 }: Params) => {
   // Ensure pinLabels is defined
   const safePinLabels = pinLabels ?? {}
   const cadComponent = circuitJson.find((item) => item.type === "cad_component")
-  const footprintTsx = generateFootprintTsx(circuitJson)
+  const footprintTsx = generateFootprintTsx(
+    circuitJson,
+    componentType === "diode"
+      ? { portHintsMap: getDiodePortHintsMap(safePinLabels) }
+      : undefined,
+  )
 
   // Simplify pin labels to include only the second element
   const simplifiedPinLabels = Object.fromEntries(
@@ -50,6 +87,33 @@ export const generateTypescriptComponent = ({
     .filter(Boolean)
     .map((line) => `        ${line}`)
     .join("\n")
+
+  if (componentType === "diode") {
+    return `
+import type { DiodeProps } from "@tscircuit/props"
+
+export const ${componentName} = (props: DiodeProps) => {
+  const { name = "D1", ...restProps } = props
+
+  return (
+    <diode
+      name={name}
+      supplierPartNumbers={${JSON.stringify(supplierPartNumbers, null, "  ")}}
+      manufacturerPartNumber="${manufacturerPartNumber}"
+      footprint={${footprintTsx}}
+      ${
+        objUrl || stepUrl
+          ? `cadModel={{
+${cadModelLines}
+      }}`
+          : ""
+      }
+      {...restProps}
+    />
+  )
+}
+`.trim()
+  }
 
   return `
 import type { ChipProps } from "@tscircuit/props"

--- a/lib/websafe/convert-to-typescript-component/index.tsx
+++ b/lib/websafe/convert-to-typescript-component/index.tsx
@@ -7,6 +7,7 @@ import {
 import { normalizeManufacturerPartNumber } from "lib/utils/normalize-manufacturer-part-number"
 import { getEasyEdaCadModelPlacement } from "../get-easyeda-cad-model-placement"
 import { generateTypescriptComponent } from "./generate-typescript-component"
+import { isDiodeCategoryComponent } from "./is-diode-category-component"
 
 export const convertRawEasyToTsx = async ({ rawEasy }: { rawEasy: any }) => {
   const betterEasy = EasyEdaJsonSchema.parse(rawEasy)
@@ -80,6 +81,7 @@ export const convertBetterEasyToTsx = async ({
     stepUrl: modelStepUrl,
     circuitJson,
     supplierPartNumbers,
+    componentType: isDiodeCategoryComponent(betterEasy) ? "diode" : "chip",
   })
 }
 

--- a/lib/websafe/convert-to-typescript-component/is-diode-category-component.ts
+++ b/lib/websafe/convert-to-typescript-component/is-diode-category-component.ts
@@ -1,0 +1,16 @@
+import type { BetterEasyEdaJson } from "lib/schemas/easy-eda-json-schema"
+import { categoryValueContainsDiode } from "./category-value-contains-diode"
+
+export const isDiodeCategoryComponent = (
+  betterEasy: BetterEasyEdaJson,
+): boolean => {
+  const cPara = betterEasy.dataStr.head.c_para
+  return [
+    betterEasy.tags,
+    cPara.category,
+    cPara.Category,
+    cPara["LCSC Category"],
+    cPara["JLCPCB Category"],
+    betterEasy.category,
+  ].some(categoryValueContainsDiode)
+}

--- a/lib/websafe/generate-footprint-tsx.ts
+++ b/lib/websafe/generate-footprint-tsx.ts
@@ -2,8 +2,22 @@ import { mmStr } from "@tscircuit/mm"
 import type { AnyCircuitElement } from "circuit-json"
 import { su } from "@tscircuit/circuit-json-util"
 
+interface GenerateFootprintTsxOptions {
+  portHintsMap?: Record<string, string[]>
+}
+
+const mapPortHints = (
+  portHints: string[] | undefined,
+  portHintsMap: Record<string, string[]> | undefined,
+): string[] | undefined => {
+  if (!portHintsMap || !portHints) return portHints
+
+  return portHints.flatMap((hint) => portHintsMap[hint] ?? [hint])
+}
+
 export const generateFootprintTsx = (
   circuitJson: AnyCircuitElement[],
+  options: GenerateFootprintTsxOptions = {},
 ): string => {
   const holes = su(circuitJson).pcb_hole.list()
   const platedHoles = su(circuitJson).pcb_plated_hole.list()
@@ -33,21 +47,21 @@ export const generateFootprintTsx = (
         : ""
 
       elementStrings.push(
-        `<platedhole  portHints={${JSON.stringify(platedHole.port_hints)}} pcbX="${mmStr(platedHole.x)}" pcbY="${mmStr(platedHole.y)}" holeWidth="${mmStr(platedHole.hole_width)}" holeHeight="${mmStr(platedHole.hole_height)}" outerWidth="${mmStr(platedHole.outer_width)}" outerHeight="${mmStr(platedHole.outer_height)}"${rotation} shape="${platedHole.shape}" />`,
+        `<platedhole  portHints={${JSON.stringify(mapPortHints(platedHole.port_hints, options.portHintsMap))}} pcbX="${mmStr(platedHole.x)}" pcbY="${mmStr(platedHole.y)}" holeWidth="${mmStr(platedHole.hole_width)}" holeHeight="${mmStr(platedHole.hole_height)}" outerWidth="${mmStr(platedHole.outer_width)}" outerHeight="${mmStr(platedHole.outer_height)}"${rotation} shape="${platedHole.shape}" />`,
       )
     } else if (platedHole.shape === "pill_hole_with_rect_pad") {
       elementStrings.push(
-        `<platedhole  portHints={${JSON.stringify(platedHole.port_hints)}} pcbX="${mmStr(platedHole.x)}" pcbY="${mmStr(platedHole.y)}" holeWidth="${mmStr(platedHole.hole_width)}" holeHeight="${mmStr(platedHole.hole_height)}" outerWidth="${mmStr(platedHole.rect_pad_width)}" outerHeight="${mmStr(platedHole.rect_pad_height)}" shape="pill" />`,
+        `<platedhole  portHints={${JSON.stringify(mapPortHints(platedHole.port_hints, options.portHintsMap))}} pcbX="${mmStr(platedHole.x)}" pcbY="${mmStr(platedHole.y)}" holeWidth="${mmStr(platedHole.hole_width)}" holeHeight="${mmStr(platedHole.hole_height)}" outerWidth="${mmStr(platedHole.rect_pad_width)}" outerHeight="${mmStr(platedHole.rect_pad_height)}" shape="pill" />`,
       )
     } else if (platedHole.shape === "circle") {
       elementStrings.push(
-        `<platedhole  portHints={${JSON.stringify(platedHole.port_hints)}} pcbX="${mmStr(platedHole.x)}" pcbY="${mmStr(platedHole.y)}" outerDiameter="${mmStr(platedHole.outer_diameter)}" holeDiameter="${mmStr(platedHole.hole_diameter)}" shape="circle" />`,
+        `<platedhole  portHints={${JSON.stringify(mapPortHints(platedHole.port_hints, options.portHintsMap))}} pcbX="${mmStr(platedHole.x)}" pcbY="${mmStr(platedHole.y)}" outerDiameter="${mmStr(platedHole.outer_diameter)}" holeDiameter="${mmStr(platedHole.hole_diameter)}" shape="circle" />`,
       )
     } else if (platedHole.shape === "rotated_pill_hole_with_rect_pad") {
       const rotation = platedHole.hole_ccw_rotation || 0
 
       elementStrings.push(
-        `<platedhole  portHints={${JSON.stringify(platedHole.port_hints)}} pcbX="${mmStr(platedHole.x)}" pcbY="${mmStr(platedHole.y)}" holeWidth="${mmStr(platedHole.hole_width)}" holeHeight="${mmStr(platedHole.hole_height)}" outerWidth="${mmStr(platedHole.rect_pad_width)}" outerHeight="${mmStr(platedHole.rect_pad_height)}" rectPad={true} pcbRotation="${rotation}deg" shape="pill" />`,
+        `<platedhole  portHints={${JSON.stringify(mapPortHints(platedHole.port_hints, options.portHintsMap))}} pcbX="${mmStr(platedHole.x)}" pcbY="${mmStr(platedHole.y)}" holeWidth="${mmStr(platedHole.hole_width)}" holeHeight="${mmStr(platedHole.hole_height)}" outerWidth="${mmStr(platedHole.rect_pad_width)}" outerHeight="${mmStr(platedHole.rect_pad_height)}" rectPad={true} pcbRotation="${rotation}deg" shape="pill" />`,
       )
     }
   }
@@ -55,18 +69,18 @@ export const generateFootprintTsx = (
   for (const smtPad of smtPads) {
     if (smtPad.shape === "circle") {
       elementStrings.push(
-        `<smtpad portHints={${JSON.stringify(smtPad.port_hints)}} pcbX="${mmStr(smtPad.x)}" pcbY="${mmStr(smtPad.y)}" radius="${mmStr(smtPad.radius)}" shape="circle" />`,
+        `<smtpad portHints={${JSON.stringify(mapPortHints(smtPad.port_hints, options.portHintsMap))}} pcbX="${mmStr(smtPad.x)}" pcbY="${mmStr(smtPad.y)}" radius="${mmStr(smtPad.radius)}" shape="circle" />`,
       )
     } else if (smtPad.shape === "rect") {
       elementStrings.push(
-        `<smtpad portHints={${JSON.stringify(smtPad.port_hints)}} pcbX="${mmStr(smtPad.x)}" pcbY="${mmStr(smtPad.y)}" width="${mmStr(smtPad.width)}" height="${mmStr(smtPad.height)}" shape="rect" />`,
+        `<smtpad portHints={${JSON.stringify(mapPortHints(smtPad.port_hints, options.portHintsMap))}} pcbX="${mmStr(smtPad.x)}" pcbY="${mmStr(smtPad.y)}" width="${mmStr(smtPad.width)}" height="${mmStr(smtPad.height)}" shape="rect" />`,
       )
     } else if (smtPad.shape === "polygon") {
       const pointsStr = smtPad.points
         .map((p) => `{x: "${mmStr(p.x)}", y: "${mmStr(p.y)}"}`)
         .join(", ")
       elementStrings.push(
-        `<smtpad portHints={${JSON.stringify(smtPad.port_hints)}} points={[${pointsStr}]} shape="polygon" />`,
+        `<smtpad portHints={${JSON.stringify(mapPortHints(smtPad.port_hints, options.portHintsMap))}} points={[${pointsStr}]} shape="polygon" />`,
       )
     }
   }

--- a/tests/convert-to-ts/C57759-to-ts.test.ts
+++ b/tests/convert-to-ts/C57759-to-ts.test.ts
@@ -1,0 +1,63 @@
+import { expect, it } from "bun:test"
+import { runTscircuitCode } from "tscircuit"
+import diodeRawEasy from "../assets/C57759.raweasy.json"
+import { wrapTsxWithBoardFor3dSnapshot } from "../fixtures/wrap-tsx-with-board-for-3d-snapshot"
+import { EasyEdaJsonSchema } from "lib/schemas/easy-eda-json-schema"
+import { convertBetterEasyToTsx } from "lib/websafe/convert-to-typescript-component"
+
+it("should convert diode category components to diode elements", async () => {
+  const betterEasy = EasyEdaJsonSchema.parse({
+    ...diodeRawEasy,
+    tags: [],
+    category: "Diode",
+  })
+  const result = await convertBetterEasyToTsx({ betterEasy })
+
+  expect(result).toMatchInlineSnapshot(`
+    "import type { DiodeProps } from "@tscircuit/props"
+
+    export const A_1N4148WS = (props: DiodeProps) => {
+      const { name = "D1", ...restProps } = props
+
+      return (
+        <diode
+          name={name}
+          supplierPartNumbers={{
+      "jlcpcb": [
+        "C57759"
+      ]
+    }}
+          manufacturerPartNumber="A_1N4148WS"
+          footprint={<footprint>
+            <smtpad portHints={["pin2","cathode"]} pcbX="-1.172591mm" pcbY="0mm" width="0.999998mm" height="0.7500112mm" shape="rect" />
+    <smtpad portHints={["pin1","anode"]} pcbX="1.172591mm" pcbY="0mm" width="0.999998mm" height="0.7500112mm" shape="rect" />
+    <silkscreenpath route={[{"x":0.9012427999999773,"y":-0.726211400000011},{"x":0.9012427999999773,"y":-0.5199887999999646}]} />
+    <silkscreenpath route={[{"x":0.9012427999999773,"y":0.726211400000011},{"x":0.9012427999999773,"y":0.5299964000000728}]} />
+    <silkscreenpath route={[{"x":-0.8512047999998913,"y":0.726211400000011},{"x":0.9012427999999773,"y":0.726211400000011}]} />
+    <silkscreenpath route={[{"x":-0.8512047999998913,"y":-0.726211400000011},{"x":0.9012427999999773,"y":-0.726211400000011}]} />
+    <silkscreenpath route={[{"x":-0.44676059999994777,"y":0.726211400000011},{"x":-0.44676059999994777,"y":-0.726211400000011}]} />
+    <silkscreentext text="{NAME}" pcbX="0.004191mm" pcbY="1.6604mm" anchorAlignment="center" fontSize="1mm" />
+    <courtyardoutline outline={[{"x":-1.5158089999998765,"y":0.9103999999999814},{"x":1.5241910000000871,"y":0.9103999999999814},{"x":1.5241910000000871,"y":-0.8849999999999909},{"x":-1.5158089999998765,"y":-0.8849999999999909},{"x":-1.5158089999998765,"y":0.9103999999999814}]} />
+          </footprint>}
+          cadModel={{
+            objUrl: "https://modelcdn.tscircuit.com/easyeda_models/assets/C57759.obj?uuid=973acf8a660c48b1975f1ba1c890421a",
+            stepUrl: "https://modelcdn.tscircuit.com/easyeda_models/assets/C57759.step?uuid=973acf8a660c48b1975f1ba1c890421a",
+            pcbRotationOffset: 0,
+            modelOriginPosition: { x: 0, y: 0, z: -0.01 },
+          }}
+          {...restProps}
+        />
+      )
+    }"
+  `)
+
+  const circuitJson = await runTscircuitCode(
+    wrapTsxWithBoardFor3dSnapshot(result),
+  )
+  const sourceComponent = circuitJson.find(
+    (element) => element.type === "source_component",
+  )
+
+  expect(sourceComponent?.ftype).toBe("simple_diode")
+  expect(sourceComponent?.supplier_part_numbers).toEqual({ jlcpcb: ["C57759"] })
+})

--- a/tests/fixtures/wrap-tsx-with-board-for-3d-snapshot.ts
+++ b/tests/fixtures/wrap-tsx-with-board-for-3d-snapshot.ts
@@ -1,27 +1,31 @@
 export const wrapTsxWithBoardFor3dSnapshot = (tsx: string): string => {
   const lines = tsx.split("\n")
-  const chipLineIndex = lines.findIndex((line) => line.includes("<chip"))
+  const componentLineIndex = lines.findIndex(
+    (line) => line.includes("<chip") || line.includes("<diode"),
+  )
 
-  if (chipLineIndex === -1) {
-    throw new Error("Expected generated TSX to contain a root <chip> element")
+  if (componentLineIndex === -1) {
+    throw new Error(
+      "Expected generated TSX to contain a root <chip> or <diode> element",
+    )
   }
 
-  const chipIndent = lines[chipLineIndex].match(/^\s*/)![0]
-  lines.splice(chipLineIndex, 0, `${chipIndent}<board >`)
+  const componentIndent = lines[componentLineIndex].match(/^\s*/)![0]
+  lines.splice(componentLineIndex, 0, `${componentIndent}<board >`)
 
-  let chipCloseLineIndex = -1
-  for (let i = lines.length - 1; i > chipLineIndex; i--) {
+  let componentCloseLineIndex = -1
+  for (let i = lines.length - 1; i > componentLineIndex; i--) {
     if (lines[i].trim() === "/>") {
-      chipCloseLineIndex = i
+      componentCloseLineIndex = i
       break
     }
   }
 
-  if (chipCloseLineIndex === -1) {
+  if (componentCloseLineIndex === -1) {
     throw new Error("Expected generated TSX to contain a closing root /> line")
   }
 
-  lines.splice(chipCloseLineIndex + 1, 0, `${chipIndent}</board>`)
+  lines.splice(componentCloseLineIndex + 1, 0, `${componentIndent}</board>`)
 
   return lines.join("\n")
 }


### PR DESCRIPTION
Converts EasyEDA components categorized as diodes into <diode> components instead of generic <chip> components.

  Adds diode category detection from EasyEDA category/tag metadata, preserves the optional root category field in the schema, and emits DiodeProps output for generated diode components.

  Also remaps diode footprint port hints so EasyEDA anode/cathode labels align with tscircuit diode polarity (pin1/anode, pin2/cathode) instead of blindly preserving EasyEDA pin numbers.
