### PR TITLE
fix: improve error messages to include part number and descriptive context

### DIFF
--- a/lib/websafe/fetch-easyeda-json.ts
+++ b/lib/websafe/fetch-easyeda-json.ts
@@ -107,12 +107,12 @@ export async function fetchEasyEDAComponent(
   })
 
   if (!searchResponse.ok) {
-    throw new Error("Failed to search for the component")
+    throw new Error(`Failed to search for component ${jlcpcbPartNumber} from EasyEDA API`)
   }
 
   const searchResult = await searchResponse.json()
   if (!searchResult.success || !searchResult.result.lists.lcsc.length) {
-    throw new Error("Component not found")
+    throw new Error(`Component with JLCPCB part number ${jlcpcbPartNumber} not found in EasyEDA database. This part may exist on JLCPCB but lacks EasyEDA footprint data.`)
   }
 
   const bestMatchComponent =
@@ -133,7 +133,7 @@ export async function fetchEasyEDAComponent(
   })
 
   if (!componentResponse.ok) {
-    throw new Error("Failed to fetch the component details")
+    throw new Error(`Failed to fetch component details for ${jlcpcbPartNumber} from EasyEDA API`)
   }
 
   const componentResult = await componentResponse.json()

--- a/tests/fetch-tests/c9900037709.test.ts
+++ b/tests/fetch-tests/c9900037709.test.ts
@@ -1,0 +1,8 @@
+import { it, expect } from "bun:test"
+import { fetchEasyEDAComponent } from "lib/websafe/fetch-easyeda-json"
+
+it("should throw descriptive error for C9900037709 (not in EasyEDA database)", async () => {
+  await expect(fetchEasyEDAComponent("C9900037709")).rejects.toThrow(
+    "Component with JLCPCB part number C9900037709 not found in EasyEDA database",
+  )
+})


### PR DESCRIPTION
Fixes #288

## Changes

1. All error messages in fetchEasyEDAComponent now include the JLCPCB part number for easier debugging
2. When a component is not found in EasyEDA database, the error message now explains that the part may exist on JLCPCB but lacks EasyEDA footprint data
3. Added test for C9900037709 confirming the descriptive error is thrown

## Before

Error: Component not found

## After

Error: Component with JLCPCB part number C9900037709 not found in EasyEDA database. This part may exist on JLCPCB but lacks EasyEDA footprint data.

## Testing

bun test tests/fetch-tests/c9900037709.test.ts passes