### PR TITLE
Fix bottom silkscreen layer for tracks and arcs

### DIFF
--- a/lib/convert-easyeda-json-to-tscircuit-soup-json.ts
+++ b/lib/convert-easyeda-json-to-tscircuit-soup-json.ts
@@ -110,7 +110,7 @@ const handleSilkscreenPath = (
     type: "pcb_silkscreen_path",
     pcb_silkscreen_path_id: `pcb_silkscreen_path_${index + 1}`,
     pcb_component_id: "pcb_component_1",
-    layer: "top", // Assuming all silkscreen is on top layer
+    layer: getSideFromLayer(track.layer),
     route: track.points.map((point) => ({
       x: milx10(point.x),
       y: milx10(point.y),
@@ -144,7 +144,7 @@ const handleSilkscreenArc = (arc: z.infer<typeof ArcSchema>, index: number) => {
     type: "pcb_silkscreen_path",
     pcb_silkscreen_path_id: `pcb_silkscreen_arc_${index + 1}`,
     pcb_component_id: "pcb_component_1",
-    layer: "top", // Assuming all silkscreen is on top layer
+    layer: getSideFromLayer(arc.layer),
     route: arcPath.map((p) => ({
       x: milx10(p.x),
       y: milx10(p.y),

--- a/tests/convert-to-soup-tests/silkscreen-bottom-layer.test.ts
+++ b/tests/convert-to-soup-tests/silkscreen-bottom-layer.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test"
+import { convertEasyEdaJsonToCircuitJson, EasyEdaJsonSchema } from "lib/index"
+import rawJson from "tests/assets/C265111.raweasy.json"
+
+test("bottom-layer (layer 4) silkscreen TRACK and ARC map to the bottom layer", () => {
+  const convert = (extraShapes: string[]) => {
+    const raw = structuredClone(rawJson) as any
+    for (const shape of extraShapes) {
+      raw.packageDetail.dataStr.shape.push(shape)
+    }
+    return convertEasyEdaJsonToCircuitJson(EasyEdaJsonSchema.parse(raw), {
+      shouldRecenter: false,
+    }) as Array<{ type: string; layer?: string }>
+  }
+
+  const silkscreenPaths = <T extends { type: string }>(elements: T[]) =>
+    elements.filter((element) => element.type === "pcb_silkscreen_path")
+
+  const baseline = convert([])
+  const withBottom = convert([
+    "TRACK~1~4~~3990 3010 3995 3010~ggeBOTTRACK~0",
+    "ARC~1~4~~M 3990 3000 A 2 2 0 0 0 3994 3000~ggeBOTARC~0",
+  ])
+
+  const newPaths = silkscreenPaths(withBottom).slice(
+    silkscreenPaths(baseline).length,
+  )
+
+  expect(newPaths).toHaveLength(2)
+  for (const path of newPaths) {
+    expect(path.layer).toBe("bottom")
+  }
+})


### PR DESCRIPTION
Fixes #398.

## Summary

- Use the parsed EasyEDA layer when converting silkscreen `TRACK` shapes.
- Use the parsed EasyEDA layer when converting silkscreen `ARC` shapes.
- Add a regression test covering injected layer 4 bottom-side `TRACK` and `ARC` shapes.

Layer 4 is already recognized as bottom silkscreen by `getSideFromLayer`, and `CIRCLE` silkscreen conversion already uses that helper. This applies the same mapping to `TRACK` and `ARC` instead of hardcoding `top`.

## Tests

```text
bun test tests/convert-to-soup-tests/silkscreen-bottom-layer.test.ts
bun test tests/parse-tests/single-letter-shape-schema.test.ts
bun run build
bun test tests/convert-to-ts/C472489-to-ts.test.ts
```

I also ran the full `bun test` suite. It hit the existing 5000ms timeout on `tests/convert-to-ts/C472489-to-ts.test.ts` during the full run, then that same test passed in isolation in about 5.46s.
