### PR TITLE
fix: CLI tsx conversion crashes — pass { rawEasy } to convertRawEasyToTsx

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const soupJson = convertEasyEdaJsonToCircuitJson(rawEasyJson)
 import { convertRawEasyEdaToTs } from "easyeda"
 
 // Convert to TypeScript React component
-const tsxComponent = await convertRawEasyEdaToTs(rawEasyJson)
+const tsxComponent = await convertRawEasyEdaToTs({ rawEasy: rawEasyJson })
 ```
 
 ### Full Example: Fetching and Converting to TSX
@@ -36,7 +36,7 @@ import { fetchEasyEDAComponent, convertRawEasyEdaToTs } from "easyeda"
 
 async function convertPartNumberToTsx(partNumber: string) {
   const rawEasyJson = await fetchEasyEDAComponent(partNumber)
-  const tsxComponent = await convertRawEasyEdaToTs(rawEasyJson)
+  const tsxComponent = await convertRawEasyEdaToTs({ rawEasy: rawEasyJson })
   return tsxComponent
 }
 

--- a/lib/convert-easyeda-json-to-various-formats.ts
+++ b/lib/convert-easyeda-json-to-various-formats.ts
@@ -84,7 +84,7 @@ export const convertEasyEdaJsonToVariousFormats = async ({
       outputFilename.endsWith(".tsx") ||
       outputFilename.endsWith(".ts")
     ) {
-      const tsComp = await convertRawEasyToTsx(rawEasyEdaJson)
+      const tsComp = await convertRawEasyToTsx({ rawEasy: rawEasyEdaJson })
       await fs.writeFile(outputFilename, tsComp)
       console.log(
         `[${jlcpcbPartNumberOrFilepath}] Saved TypeScript component: ${outputFilename}`,

--- a/tests/convert-easyeda-json-to-various-formats.test.ts
+++ b/tests/convert-easyeda-json-to-various-formats.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { convertEasyEdaJsonToVariousFormats } from "lib/convert-easyeda-json-to-various-formats"
+
+test("converts a local raweasy.json file to a tsx component file", async () => {
+  const inputPath = path.join(import.meta.dir, "assets/C46749.raweasy.json")
+  const outputDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), "easyeda-cli-test-"),
+  )
+  const outputPath = path.join(outputDir, "C46749.tsx")
+
+  await convertEasyEdaJsonToVariousFormats({
+    jlcpcbPartNumberOrFilepath: inputPath,
+    outputFilename: outputPath,
+    outputFormat: "tsx",
+  })
+
+  const output = await fs.readFile(outputPath, "utf-8")
+  expect(output).toContain("<chip")
+  expect(output).toContain("C46749")
+})


### PR DESCRIPTION
fixes #400

### Problem

`easyeda convert -i <part> -o <file>.tsx` crashed for every part number — even the README's own example:

```bash
easyeda convert -i C46749 -o C46749.tsx
```

```
Error: [
  {
    "code": "invalid_type",
    "expected": "object",
    "received": "undefined",
    "path": [],
    "message": "Required"
  }
]
```

### Fix

`convertEasyEdaJsonToVariousFormats` passed the raw EasyEDA JSON directly to `convertRawEasyToTsx`, which expects `{ rawEasy }` — so `rawEasy` destructured to `undefined` and `EasyEdaJsonSchema.parse` threw. One-line change:

```diff
- const tsComp = await convertRawEasyToTsx(rawEasyEdaJson)
+ const tsComp = await convertRawEasyToTsx({ rawEasy: rawEasyEdaJson })
```

TypeScript can't catch this because the input can come from `JSON.parse` (typed `any`).

Also updated the two README library examples that still showed the old `convertRawEasyEdaToTs(rawEasyJson)` calling convention.

### Testing

- **New regression test** `tests/convert-easyeda-json-to-various-formats.test.ts`: converts a local `tests/assets/C46749.raweasy.json` to tsx (no network needed). It fails on current `main` with the exact ZodError above and passes with this fix.
- `bun test` — suite green (the only failures ever observed were pre-existing 5s network timeouts in `convert-to-ts` tests, which also occur on clean `main` and pass when run in isolation)
- `bun run format:check` ✅
- `bunx tsc --noEmit` ✅
- `bun run build` ✅
- Verified the real CLI end-to-end after the fix: C46749, C2879853, C9900014805 and C5360621 all produce valid `.tsx` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TPt9rFF6Uo76scbFcoyZ4