### PR TITLE
fix(schema): accept string or number for szlcsc/lcsc id

### DIFF
--- a/lib/schemas/easy-eda-json-schema.ts
+++ b/lib/schemas/easy-eda-json-schema.ts
@@ -11,7 +11,9 @@ export const maybeNumber = z
   .pipe(z.number().nullable().optional())
 
 export const SzlcscSchema = z.object({
-  id: z.number(),
+  // EasyEDA returns this id as a number for some parts and a string for others
+  // (e.g. C356849); the value is unused, so accept either to avoid import crashes.
+  id: z.union([z.number(), z.string()]),
   number: z.string(),
   step: z.number().optional(),
   min: z.number().optional(),
@@ -22,7 +24,7 @@ export const SzlcscSchema = z.object({
 })
 
 export const LcscSchema = z.object({
-  id: z.number(),
+  id: z.union([z.number(), z.string()]),
   number: z.string(),
   step: z.number().optional(),
   min: z.number().optional(),

--- a/tests/szlcsc-schema-id.test.ts
+++ b/tests/szlcsc-schema-id.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+import { SzlcscSchema, LcscSchema } from "lib/schemas/easy-eda-json-schema"
+
+// EasyEDA returns the szlcsc/lcsc `id` as a number for some parts and a string
+// for others (e.g. C356849), which used to crash `tsci import` on those parts.
+describe("szlcsc/lcsc id accepts number or string", () => {
+  for (const [name, schema] of [
+    ["SzlcscSchema", SzlcscSchema],
+    ["LcscSchema", LcscSchema],
+  ] as const) {
+    test(`${name} accepts a numeric id`, () => {
+      expect(schema.safeParse({ id: 2384679, number: "C356849" }).success).toBe(true)
+    })
+    test(`${name} accepts a string id`, () => {
+      expect(schema.safeParse({ id: "2384679", number: "C356849" }).success).toBe(true)
+    })
+  }
+})

--- a/tests/szlcsc-schema-id.test.ts
+++ b/tests/szlcsc-schema-id.test.ts
@@ -9,10 +9,14 @@ describe("szlcsc/lcsc id accepts number or string", () => {
     ["LcscSchema", LcscSchema],
   ] as const) {
     test(`${name} accepts a numeric id`, () => {
-      expect(schema.safeParse({ id: 2384679, number: "C356849" }).success).toBe(true)
+      expect(schema.safeParse({ id: 2384679, number: "C356849" }).success).toBe(
+        true,
+      )
     })
     test(`${name} accepts a string id`, () => {
-      expect(schema.safeParse({ id: "2384679", number: "C356849" }).success).toBe(true)
+      expect(
+        schema.safeParse({ id: "2384679", number: "C356849" }).success,
+      ).toBe(true)
     })
   }
 })


### PR DESCRIPTION
## Problem

`tsci import <lcsc-id>` (and any EasyEDA fetch) crashes for certain parts, e.g. `C356849` (Ebyte E73-2G4M08S1C), with:

```
szlcsc.id: Expected number, received string
```

EasyEDA's API returns `szlcsc.id` (and `lcsc.id`) as a **number for some parts and a string for others**. `SzlcscSchema`/`LcscSchema` hardcode `z.number()`, so validation throws and the import aborts.

## Fix

The `id` field is not consumed anywhere downstream (only validated), so widen it to `z.union([z.number(), z.string()])`. A separate `number: z.string()` field already carries the `C...` code, so this only relaxes the internal id.

## Test

Adds a no-network unit test asserting both schemas accept a numeric and a string `id`.