### PR TITLE
fix: distinguish EasyEDA HTTP 403 rate limiting from component lookup failure

### DIFF
--- a/lib/websafe/fetch-easyeda-json.ts
+++ b/lib/websafe/fetch-easyeda-json.ts
@@ -107,7 +107,14 @@ export async function fetchEasyEDAComponent(
   })
 
   if (!searchResponse.ok) {
-    throw new Error("Failed to search for the component")
+    if (searchResponse.status === 403) {
+      throw new Error(
+        `EasyEDA API rate limit exceeded while searching for "${jlcpcbPartNumber}" (HTTP 403). EasyEDA rate-limits by IP — the part number is likely fine. Wait ~2 minutes and try again.`,
+      )
+    }
+    throw new Error(
+      `Failed to search for the component (HTTP ${searchResponse.status})`,
+    )
   }
 
   const searchResult = await searchResponse.json()
@@ -133,7 +140,14 @@ export async function fetchEasyEDAComponent(
   })
 
   if (!componentResponse.ok) {
-    throw new Error("Failed to fetch the component details")
+    if (componentResponse.status === 403) {
+      throw new Error(
+        `EasyEDA API rate limit exceeded while fetching "${jlcpcbPartNumber}" (HTTP 403). EasyEDA rate-limits by IP — the part number is likely fine. Wait ~2 minutes and try again.`,
+      )
+    }
+    throw new Error(
+      `Failed to fetch the component details (HTTP ${componentResponse.status})`,
+    )
   }
 
   const componentResult = await componentResponse.json()

--- a/tests/fetch-tests/rate-limit-403.test.ts
+++ b/tests/fetch-tests/rate-limit-403.test.ts
@@ -1,0 +1,78 @@
+import { expect, it } from "bun:test"
+import { fetchEasyEDAComponent } from "lib/websafe/fetch-easyeda-json"
+
+// EasyEDA's component API rate-limits by IP and answers HTTP 403 (not 429)
+// once tripped — see issue #409. These tests use the injectable fetch option
+// so they never touch the network.
+
+const searchSuccessBody = (partNumber: string) =>
+  JSON.stringify({
+    success: true,
+    result: {
+      lists: {
+        lcsc: [
+          {
+            uuid: "test-uuid-1234",
+            dataStr: { head: { c_para: { "Supplier Part": partNumber } } },
+          },
+        ],
+      },
+    },
+  })
+
+it("surfaces a search-request HTTP 403 as rate limiting, not a component lookup failure", async () => {
+  const fetch403 = async () =>
+    new Response("<html>403 Forbidden</html>", { status: 403 })
+
+  expect(
+    fetchEasyEDAComponent("C11702", {
+      fetch: fetch403 as unknown as typeof globalThis.fetch,
+    }),
+  ).rejects.toThrow(/rate limit/i)
+})
+
+it("surfaces a component-details HTTP 403 as rate limiting", async () => {
+  let callCount = 0
+  const fetchSearchOkThen403 = async () => {
+    callCount += 1
+    if (callCount === 1) {
+      return new Response(searchSuccessBody("C11702"), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    }
+    return new Response("<html>403 Forbidden</html>", { status: 403 })
+  }
+
+  expect(
+    fetchEasyEDAComponent("C11702", {
+      fetch: fetchSearchOkThen403 as unknown as typeof globalThis.fetch,
+      includeModelMetadata: false,
+    }),
+  ).rejects.toThrow(/rate limit/i)
+})
+
+it("keeps 'Component not found' distinct from rate limiting", async () => {
+  const fetchEmptySearch = async () =>
+    new Response(
+      JSON.stringify({ success: true, result: { lists: { lcsc: [] } } }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    )
+
+  expect(
+    fetchEasyEDAComponent("C999999999", {
+      fetch: fetchEmptySearch as unknown as typeof globalThis.fetch,
+    }),
+  ).rejects.toThrow("Component not found")
+})
+
+it("includes the HTTP status in non-403 search failures", async () => {
+  const fetch500 = async () =>
+    new Response("Internal Server Error", { status: 500 })
+
+  expect(
+    fetchEasyEDAComponent("C11702", {
+      fetch: fetch500 as unknown as typeof globalThis.fetch,
+    }),
+  ).rejects.toThrow(/HTTP 500/)
+})


### PR DESCRIPTION
Fixes #409 — the error-text distinction (suggestion 3 of the issue).

## Problem

EasyEDA's component API rate-limits by IP and answers **HTTP 403** once tripped (not 429, no `Retry-After`). `fetchEasyEDAComponent` treated any non-success response as a lookup failure, so a throttled batch surfaced as:

```
Error: Failed to search for the component
```

which points the user at the part number. The part is fine; the request was throttled — as measured in #409, every LCSC id 403s identically mid-cooldown and recovers after ~2 minutes.

## Change (minimal, one concern)

- A **403** on either the search request or the component-details request now throws a rate-limit-specific error naming the part, stating it's an IP-based limit, and giving the ~2 minute cooldown hint from the issue's measurements.
- Other non-success statuses keep their existing messages but now include the HTTP status code.
- `Component not found` (successful response, empty result list) is **unchanged** — it stays distinct from rate limiting, which is the core complaint in #409.

Retry/backoff, serialising the parts-engine batch, and CDN proxying (suggestions 1, 2, 4) are deliberately left as follow-ups — they're behaviour/architecture decisions, and per review feedback on other PRs I'm keeping one change per PR.

## Tests (red→green)

`tests/fetch-tests/rate-limit-403.test.ts` — uses the existing injectable `fetch` option, so **no network** (unlike the live-API fetch tests, these can't themselves be rate-limited):

1. search-request 403 → `/rate limit/i` error (was: generic lookup failure) — **red before, green after**
2. component-details 403 → `/rate limit/i` error — **red before, green after**
3. empty search result → still exactly `Component not found` (guards the distinction)
4. non-403 failure (500) → message includes `HTTP 500` — **red before, green after**

`bun test` on the new file: 4 pass. `tsc --noEmit` clean. `biome check` clean.

Note: #393 (May) adds part numbers to these messages but doesn't distinguish status codes; this PR is orthogonal and touches only the status-code branches.
