### PR TITLE
fix: pass rawEasy object shape to convertRawEasyToTsx in CLI convert (#400)

### DIFF
--- a/lib/convert-easyeda-json-to-various-formats.ts
+++ b/lib/convert-easyeda-json-to-various-formats.ts
@@ -1,8 +1,8 @@
-import { fetchEasyEDAComponent } from "lib/websafe/fetch-easyeda-json"
 import { convertEasyEdaJsonToCircuitJson } from "lib/convert-easyeda-json-to-tscircuit-soup-json"
 import { EasyEdaJsonSchema } from "lib/schemas/easy-eda-json-schema"
-import { convertRawEasyToTsx } from "lib/websafe/convert-to-typescript-component"
 import { normalizeManufacturerPartNumber } from "lib/utils/normalize-manufacturer-part-number"
+import { convertRawEasyToTsx } from "lib/websafe/convert-to-typescript-component"
+import { fetchEasyEDAComponent } from "lib/websafe/fetch-easyeda-json"
 
 export const convertEasyEdaJsonToVariousFormats = async ({
   jlcpcbPartNumberOrFilepath,
@@ -84,7 +84,7 @@ export const convertEasyEdaJsonToVariousFormats = async ({
       outputFilename.endsWith(".tsx") ||
       outputFilename.endsWith(".ts")
     ) {
-      const tsComp = await convertRawEasyToTsx(rawEasyEdaJson)
+      const tsComp = await convertRawEasyToTsx({ rawEasy: rawEasyEdaJson })
       await fs.writeFile(outputFilename, tsComp)
       console.log(
         `[${jlcpcbPartNumberOrFilepath}] Saved TypeScript component: ${outputFilename}`,

--- a/tests/cli/convert-tsx-output-400.test.ts
+++ b/tests/cli/convert-tsx-output-400.test.ts
@@ -1,0 +1,34 @@
+import { expect, it } from "bun:test"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { convertEasyEdaJsonToVariousFormats } from "lib/convert-easyeda-json-to-various-formats"
+
+// https://github.com/tscircuit/easyeda-converter/issues/400
+//
+// `easyeda convert -i <part> -o <file>.tsx` crashed for every part:
+// convertRawEasyToTsx takes `{ rawEasy }` but was called with the raw JSON
+// directly, so EasyEdaJsonSchema.parse(undefined) threw. Uses a local
+// .raweasy.json asset so no network is needed.
+it("converts a local raweasy.json to a tsx component file", async () => {
+  const inputPath = path.join(
+    import.meta.dir,
+    "..",
+    "assets",
+    "C46749.raweasy.json",
+  )
+  const outputPath = path.join(
+    await fs.mkdtemp(path.join(os.tmpdir(), "easyeda-400-")),
+    "C46749.tsx",
+  )
+
+  await convertEasyEdaJsonToVariousFormats({
+    jlcpcbPartNumberOrFilepath: inputPath,
+    outputFilename: outputPath,
+    outputFormat: "tsx",
+  })
+
+  const tsx = await fs.readFile(outputPath, "utf-8")
+  expect(tsx).toContain("const pinLabels")
+  expect(tsx).toContain("<chip")
+})


### PR DESCRIPTION
Fixes #400.

## Problem

`easyeda convert -i <part> -o <file>.tsx` crashed for **every** part:

```
Error: [{"code":"invalid_type","expected":"object","received":"undefined","path":[],"message":"Required"}]
```

`convertRawEasyToTsx` takes `{ rawEasy }` but the CLI convert path (`lib/convert-easyeda-json-to-various-formats.ts:87`) called it with the raw JSON directly, so `EasyEdaJsonSchema.parse(undefined)` threw. Only `.tsx`/`.ts` output was affected — other formats never hit this call.

## Fix

One-line call-shape fix: `convertRawEasyToTsx(rawEasyEdaJson)` → `convertRawEasyToTsx({ rawEasy: rawEasyEdaJson })`.

Verified the exact repro from the issue now works:

```
$ bun cli/main.ts convert -i C46749 -o C46749.tsx
[C46749] Saved TypeScript component: C46749.tsx
```

## Verification

- Network-free regression test converting the existing local `C46749.raweasy.json` asset to a tsx file (fails on `main` with the ZodError from the issue)
- `bunx tsc --noEmit` / `biome check` — clean
