### PR TITLE
fix: explain C99 assembly-catalog part numbers in the not-found error (#390)

### DIFF
--- a/lib/websafe/fetch-easyeda-json.ts
+++ b/lib/websafe/fetch-easyeda-json.ts
@@ -119,7 +119,12 @@ export async function fetchEasyEDAComponent(
 
   const searchResult = await searchResponse.json()
   if (!searchResult.success || !searchResult.result.lists.lcsc.length) {
-    throw new Error("Component not found")
+    if (/^C99\d{6,}$/i.test(jlcpcbPartNumber)) {
+      throw new Error(
+        `Component not found: "${jlcpcbPartNumber}" is a JLCPCB assembly-catalog part number (C99xxxxxxx). These parts frequently have no EasyEDA symbol/footprint behind them, so there is nothing to convert — try searching for the underlying manufacturer part number instead.`,
+      )
+    }
+    throw new Error(`Component not found: "${jlcpcbPartNumber}"`)
   }
 
   const bestMatchComponent =

--- a/tests/fetch-tests/c99-assembly-part-error-390.test.ts
+++ b/tests/fetch-tests/c99-assembly-part-error-390.test.ts
@@ -1,0 +1,38 @@
+import { expect, it } from "bun:test"
+import { fetchEasyEDAComponent } from "lib/websafe/fetch-easyeda-json"
+
+// https://github.com/tscircuit/easyeda-converter/issues/390
+//
+// C99xxxxxxx numbers are JLCPCB assembly-catalog entries that often have no
+// EasyEDA symbol/footprint behind them (verified: both the search API and the
+// products API return nothing for C9900033429). The error should say so
+// instead of a bare "Component not found".
+it("explains that C99 assembly parts have no EasyEDA data", async () => {
+  const emptySearchFetch = (async () =>
+    new Response(
+      JSON.stringify({
+        success: true,
+        result: { lists: { lcsc: [] } },
+      }),
+      { status: 200 },
+    )) as unknown as typeof globalThis.fetch
+
+  expect(
+    fetchEasyEDAComponent("C9900033429", { fetch: emptySearchFetch }),
+  ).rejects.toThrow(/assembly-catalog part number/)
+})
+
+it("includes the part number in the generic not-found error", async () => {
+  const emptySearchFetch = (async () =>
+    new Response(
+      JSON.stringify({
+        success: true,
+        result: { lists: { lcsc: [] } },
+      }),
+      { status: 200 },
+    )) as unknown as typeof globalThis.fetch
+
+  expect(
+    fetchEasyEDAComponent("C1234", { fetch: emptySearchFetch }),
+  ).rejects.toThrow(/Component not found: "C1234"/)
+})


### PR DESCRIPTION
Progress on #390 — makes the failure explainable instead of a dead end.

## Investigation

`C9900033429` (the reported part) is a **JLCPCB assembly-catalog part number**. Verified against both EasyEDA API paths on 2026-07-24 (details in [my issue comment](https://github.com/tscircuit/easyeda-converter/issues/390#issuecomment-5070150105)):

- search API (`/api/components/search`, what `fetchEasyEDAComponent` uses): 0 results in every list (lcsc/easyeda/SMT/…)
- products API (`/api/products/C9900033429/components`): `{success:false, code:404}`

So the converter genuinely has nothing to fetch — the failure is correct, but the bare `"Component not found"` gives the user no way to understand or work around it.

## Change

- `C99\d{6,}`-prefixed parts get a specific error: identifies the number as a JLCPCB assembly-catalog entry that frequently has no EasyEDA symbol/footprint, and suggests searching the underlying manufacturer part number instead.
- The generic not-found error now includes the part number that failed.

## Verification

- Two new tests using the existing injectable `fetch` seam (no network): C99 part → assembly-catalog message; other part → generic message with part number
- Full `tests/fetch-tests` suite: 9 pass, 0 fail
- `bunx tsc --noEmit` / `biome check` — clean
