### PR TITLE
Preserve diode polarity hints on PCB pads

### DIFF
--- a/lib/convert-easyeda-json-to-tscircuit-soup-json.ts
+++ b/lib/convert-easyeda-json-to-tscircuit-soup-json.ts
@@ -2,7 +2,7 @@ import {
   findBoundsAndCenter,
   transformPCBElements,
 } from "@tscircuit/circuit-json-util"
-import { mm, mil2mm } from "@tscircuit/mm"
+import { mil2mm, mm } from "@tscircuit/mm"
 import type {
   AnyCircuitElement,
   PcbComponentInput,
@@ -21,6 +21,7 @@ import {
 import * as Soup from "circuit-json"
 import { applyToPoint, compose, scale, translate } from "transformation-matrix"
 import type { z } from "zod"
+import { DEFAULT_PCB_THICKNESS_MM } from "./constants"
 import { generateArcFromSweep, generateArcPathWithMid } from "./math/arc-utils"
 import type { BetterEasyEdaJson } from "./schemas/easy-eda-json-schema"
 import type {
@@ -34,10 +35,12 @@ import type {
   ViaSchema,
 } from "./schemas/package-detail-shape-schema"
 import { mil10ToMm } from "./utils/easyeda-unit-to-mm"
-import { getCadModelOffsetMmFromBounds } from "./websafe/get-easyeda-cad-placement-helpers"
+import { getPolarizedPinMetadata } from "./utils/get-polarized-pin-metadata"
 import { normalizePinLabels } from "./utils/normalize-pin-labels"
 import { normalizeSymbolName } from "./utils/normalize-symbol-name"
-import { DEFAULT_PCB_THICKNESS_MM } from "./constants"
+import { isDiodeCategoryComponent } from "./websafe/convert-to-typescript-component/is-diode-category-component"
+import { isLedCategoryComponent } from "./websafe/convert-to-typescript-component/is-led-category-component"
+import { getCadModelOffsetMmFromBounds } from "./websafe/get-easyeda-cad-placement-helpers"
 
 const EASYEDA_STEP_MODEL_URL =
   "https://modules.easyeda.com/qAxj6KHrDKw4blvCG8QJPs7Y"
@@ -322,6 +325,18 @@ export const convertEasyEdaJsonToCircuitJson = (
   })
 
   const normalizedPinLabels = normalizePinLabels(pinLabelSets)
+  const normalizedPinLabelsByPin = Object.fromEntries(
+    normalizedPinLabels.map((labels) => {
+      const pin = labels.find((label) => /^pin\d+$/i.test(label))!
+      return [pin, labels.filter((label) => label !== pin)]
+    }),
+  )
+  const polarizedPinMetadata =
+    pads.length === 2 &&
+    (isDiodeCategoryComponent(easyEdaJson) ||
+      isLedCategoryComponent(easyEdaJson))
+      ? getPolarizedPinMetadata(normalizedPinLabelsByPin)
+      : undefined
 
   // Add source ports and pcb_smtpads
   pads.forEach((pad, index) => {
@@ -329,6 +344,10 @@ export const convertEasyEdaJsonToCircuitJson = (
     const pinNumber = Number.parseInt(
       portHints.find((hint) => hint.match(/pin\d+/))!.replace("pin", ""),
     )
+    const canonicalPinName = `pin${pinNumber}`
+    const pcbPortHints = polarizedPinMetadata?.portHintsMap[
+      canonicalPinName
+    ] ?? [canonicalPinName]
 
     // Add source port
     circuitElements.push({
@@ -353,7 +372,7 @@ export const convertEasyEdaJsonToCircuitJson = (
         x: mil2mm(pad.center.x),
         y: mil2mm(pad.center.y),
         layers: ["top"],
-        port_hints: [`pin${pinNumber}`],
+        port_hints: pcbPortHints,
         pcb_component_id: "pcb_component_1",
         pcb_port_id: `pcb_port_${index + 1}`,
       }
@@ -509,7 +528,7 @@ export const convertEasyEdaJsonToCircuitJson = (
                   radius: Math.min(mil2mm(pad.width), mil2mm(pad.height)) / 2,
                 }),
         layer: "top",
-        port_hints: [`pin${pinNumber}`],
+        port_hints: pcbPortHints,
         pcb_component_id: "pcb_component_1",
         pcb_port_id: `pcb_port_${index + 1}`,
       } as PcbSmtPad)

--- a/lib/utils/get-polarized-pin-metadata.ts
+++ b/lib/utils/get-polarized-pin-metadata.ts
@@ -1,0 +1,53 @@
+export type PinLabels = Record<string, string | readonly string[]>
+
+export interface PolarizedPinMetadata {
+  portHintsMap: Record<string, string[]>
+  pinLabels: Record<string, string[]>
+}
+
+const getPinLabelValues = (labels: string | readonly string[]): string[] => {
+  if (typeof labels === "string") return [labels]
+  return [...labels]
+}
+
+const stripEasyEdaPolarityHintDecoration = (label: string): string =>
+  label.toLowerCase().replace(/[^a-z0-9+-]/g, "")
+
+const getPinKeySortValue = (pinKey: string): number => {
+  const match = /^pin(\d+)$/i.exec(pinKey)
+  return match ? Number(match[1]) : Number.MAX_SAFE_INTEGER
+}
+
+export const getPolarizedPinMetadata = (
+  pinLabels: PinLabels,
+): PolarizedPinMetadata | undefined => {
+  const labelsByPin = Object.entries(pinLabels).map(([pin, labels]) => ({
+    pin,
+    labels: getPinLabelValues(labels).map(stripEasyEdaPolarityHintDecoration),
+  }))
+
+  const anodePin = labelsByPin.find(({ labels }) =>
+    labels.some((label) => ["a", "anode", "pos", "+"].includes(label)),
+  )?.pin
+  const cathodePin = labelsByPin.find(({ labels }) =>
+    labels.some((label) => ["c", "k", "cathode", "neg", "-"].includes(label)),
+  )?.pin
+
+  if (!anodePin || !cathodePin || anodePin === cathodePin) return undefined
+
+  const polarizedPinEntries = (
+    [
+      [anodePin, ["anode", "pos"]],
+      [cathodePin, ["cathode", "neg"]],
+    ] satisfies Array<[string, string[]]>
+  ).sort(
+    ([pinA], [pinB]) => getPinKeySortValue(pinA) - getPinKeySortValue(pinB),
+  )
+
+  return {
+    portHintsMap: Object.fromEntries(
+      polarizedPinEntries.map(([pin, labels]) => [pin, [pin, ...labels]]),
+    ),
+    pinLabels: Object.fromEntries(polarizedPinEntries),
+  }
+}

--- a/lib/websafe/convert-to-typescript-component/generate-typescript-component.ts
+++ b/lib/websafe/convert-to-typescript-component/generate-typescript-component.ts
@@ -1,5 +1,6 @@
 import type { ChipProps, SupplierPartNumbers } from "@tscircuit/props"
 import type { AnyCircuitElement } from "circuit-json"
+import { getPolarizedPinMetadata } from "../../utils/get-polarized-pin-metadata"
 import { generateFootprintTsx } from "../generate-footprint-tsx"
 
 export type GeneratedComponentType =
@@ -19,58 +20,6 @@ interface Params {
   manufacturerPartNumber: string
   componentType?: GeneratedComponentType
   symbolTsx?: string
-}
-
-const getPinLabelValues = (labels: string | readonly string[]): string[] => {
-  if (typeof labels === "string") return [labels]
-  return [...labels]
-}
-
-const stripEasyEdaPolarityHintDecoration = (label: string): string =>
-  label.toLowerCase().replace(/[^a-z0-9+-]/g, "")
-
-const getPinKeySortValue = (pinKey: string): number => {
-  const match = /^pin(\d+)$/i.exec(pinKey)
-  return match ? Number(match[1]) : Number.MAX_SAFE_INTEGER
-}
-
-const getPolarizedPinMetadata = (
-  pinLabels: ChipProps["pinLabels"],
-):
-  | {
-      portHintsMap: Record<string, string[]>
-      pinLabels: Record<string, string[]>
-    }
-  | undefined => {
-  const labelsByPin = Object.entries(pinLabels ?? {}).map(([pin, labels]) => ({
-    pin,
-    labels: getPinLabelValues(labels).map(stripEasyEdaPolarityHintDecoration),
-  }))
-
-  const anodePin = labelsByPin.find(({ labels }) =>
-    labels.some((label) => ["a", "anode", "pos", "+"].includes(label)),
-  )?.pin
-  const cathodePin = labelsByPin.find(({ labels }) =>
-    labels.some((label) => ["c", "k", "cathode", "neg", "-"].includes(label)),
-  )?.pin
-
-  if (!anodePin || !cathodePin) return undefined
-
-  const polarizedPinEntries = (
-    [
-      [anodePin, ["anode", "pos"]],
-      [cathodePin, ["cathode", "neg"]],
-    ] satisfies Array<[string, string[]]>
-  ).sort(
-    ([pinA], [pinB]) => getPinKeySortValue(pinA) - getPinKeySortValue(pinB),
-  )
-
-  return {
-    portHintsMap: Object.fromEntries(
-      polarizedPinEntries.map(([pin, labels]) => [pin, [pin, ...labels]]),
-    ),
-    pinLabels: Object.fromEntries(polarizedPinEntries),
-  }
 }
 
 export const generateTypescriptComponent = ({

--- a/lib/websafe/generate-footprint-tsx.ts
+++ b/lib/websafe/generate-footprint-tsx.ts
@@ -1,6 +1,6 @@
+import { su } from "@tscircuit/circuit-json-util"
 import { mmStr } from "@tscircuit/mm"
 import type { AnyCircuitElement } from "circuit-json"
-import { su } from "@tscircuit/circuit-json-util"
 
 interface GenerateFootprintTsxOptions {
   portHintsMap?: Record<string, string[]>
@@ -12,7 +12,7 @@ const mapPortHints = (
 ): string[] | undefined => {
   if (!portHintsMap || !portHints) return portHints
 
-  return portHints.flatMap((hint) => portHintsMap[hint] ?? [hint])
+  return [...new Set(portHints.flatMap((hint) => portHintsMap[hint] ?? [hint]))]
 }
 
 export const generateFootprintTsx = (

--- a/tests/convert-to-soup-tests/diode-polarity-port-hints.test.ts
+++ b/tests/convert-to-soup-tests/diode-polarity-port-hints.test.ts
@@ -12,7 +12,7 @@ test("preserves normalized diode polarity hints on PCB pads", () => {
   )
   const padHints = su(circuitJson)
     .pcb_smtpad.list()
-    .map((pad) => pad.port_hints)
+    .map((pad) => pad.port_hints ?? [])
     .sort(([left], [right]) => left.localeCompare(right))
 
   expect(padHints).toEqual([

--- a/tests/convert-to-soup-tests/diode-polarity-port-hints.test.ts
+++ b/tests/convert-to-soup-tests/diode-polarity-port-hints.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test"
+import { su } from "@tscircuit/circuit-json-util"
+import { convertEasyEdaJsonToCircuitJson } from "lib/convert-easyeda-json-to-tscircuit-soup-json"
+import { EasyEdaJsonSchema } from "lib/schemas/easy-eda-json-schema"
+import { getPolarizedPinMetadata } from "lib/utils/get-polarized-pin-metadata"
+import { generateFootprintTsx } from "lib/websafe/generate-footprint-tsx"
+import diodeRawEasy from "../assets/C8598.raweasy.json"
+
+test("preserves normalized diode polarity hints on PCB pads", () => {
+  const circuitJson = convertEasyEdaJsonToCircuitJson(
+    EasyEdaJsonSchema.parse(diodeRawEasy),
+  )
+  const padHints = su(circuitJson)
+    .pcb_smtpad.list()
+    .map((pad) => pad.port_hints)
+    .sort(([left], [right]) => left.localeCompare(right))
+
+  expect(padHints).toEqual([
+    ["pin1", "cathode", "neg"],
+    ["pin2", "anode", "pos"],
+  ])
+
+  const footprintTsx = generateFootprintTsx(circuitJson, {
+    portHintsMap: getPolarizedPinMetadata({
+      pin1: ["_NEG"],
+      pin2: ["_POS"],
+    })?.portHintsMap,
+  })
+  expect(footprintTsx).toContain('portHints={["pin1","cathode","neg"]}')
+  expect(footprintTsx.match(/"cathode"/g)).toHaveLength(1)
+})

--- a/tests/get-polarized-pin-metadata.test.ts
+++ b/tests/get-polarized-pin-metadata.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test"
+import { getPolarizedPinMetadata } from "lib/utils/get-polarized-pin-metadata"
+
+describe("getPolarizedPinMetadata", () => {
+  test("normalizes anode pin 1", () => {
+    expect(getPolarizedPinMetadata({ pin1: ["A"], pin2: ["K"] })).toEqual({
+      pinLabels: {
+        pin1: ["anode", "pos"],
+        pin2: ["cathode", "neg"],
+      },
+      portHintsMap: {
+        pin1: ["pin1", "anode", "pos"],
+        pin2: ["pin2", "cathode", "neg"],
+      },
+    })
+  })
+
+  test("normalizes decorated cathode pin 1", () => {
+    expect(getPolarizedPinMetadata({ pin1: ["_NEG"], pin2: ["_POS"] })).toEqual(
+      {
+        pinLabels: {
+          pin1: ["cathode", "neg"],
+          pin2: ["anode", "pos"],
+        },
+        portHintsMap: {
+          pin1: ["pin1", "cathode", "neg"],
+          pin2: ["pin2", "anode", "pos"],
+        },
+      },
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- preserve normalized anode/cathode semantics on PCB pad `port_hints` for two-pad diode and LED imports
- extract one shared EasyEDA polarity-label normalizer for both generated components and Circuit JSON conversion
- recognize common aliases such as `A`, `K`, `_POS`, and `_NEG`
- de-duplicate generated footprint port hints

This fixes the metadata handoff where generated TSX knew diode polarity but raw Circuit JSON pads retained only their pin numbers. The downstream discovery bridge can now reliably choose `anodepin1` or `cathodepin1`.

Coordinated footprinter support: https://github.com/tscircuit/footprinter/pull/766

## Verification

- `bun test tests/get-polarized-pin-metadata.test.ts tests/convert-to-soup-tests/diode-polarity-port-hints.test.ts`
- `bun test tests/browser-bundle-websafe-guard.test.ts`
- `bun run build`
- `bunx biome check` on all changed files

The broader local suite reached the existing remote 3D-model snapshot tests, which could not access `modelcdn.tscircuit.com` in the isolated test environment; the focused conversion tests, browser bundle guard, and production build all pass.
