### PR TITLE
Remove stroke widths from EasyEDA symbols

### DIFF
--- a/lib/websafe/convert-to-typescript-component/generate-symbol-tsx.ts
+++ b/lib/websafe/convert-to-typescript-component/generate-symbol-tsx.ts
@@ -291,31 +291,31 @@ const generateShapeTsx = ({
       x: shape.position.x + shape.width / 2,
       y: shape.position.y + shape.height / 2,
     })
-    return `<schematicrect schX={${center.x}} schY={${center.y}} width={${toMillimeters(shape.width)}} height={${toMillimeters(shape.height)}} strokeWidth={${toMillimeters(shape.lineWidth)}} color=${JSON.stringify(shape.color)}${shape.fillColor && shape.fillColor !== "none" ? ` isFilled fillColor=${JSON.stringify(shape.fillColor)}` : ""} />`
+    return `<schematicrect schX={${center.x}} schY={${center.y}} width={${toMillimeters(shape.width)}} height={${toMillimeters(shape.height)}} color=${JSON.stringify(shape.color)}${shape.fillColor && shape.fillColor !== "none" ? ` isFilled fillColor=${JSON.stringify(shape.fillColor)}` : ""} />`
   }
 
   if (shape.type === "ELLIPSE") {
     const center = transformPoint(shape.center)
-    return `<schematiccircle center={{ x: ${center.x}, y: ${center.y} }} radius={${toMillimeters(Math.max(shape.radiusX, shape.radiusY))}} strokeWidth={${toMillimeters(shape.lineWidth)}} color=${JSON.stringify(shape.color)}${shape.fillColor && shape.fillColor !== "none" ? ` isFilled fillColor=${JSON.stringify(shape.fillColor)}` : ""} />`
+    return `<schematiccircle center={{ x: ${center.x}, y: ${center.y} }} radius={${toMillimeters(Math.max(shape.radiusX, shape.radiusY))}} color=${JSON.stringify(shape.color)}${shape.fillColor && shape.fillColor !== "none" ? ` isFilled fillColor=${JSON.stringify(shape.fillColor)}` : ""} />`
   }
 
   if (shape.type === "POLYLINE" || shape.type === "POLYGON") {
     const isPolygon = shape.type === "POLYGON"
     const points = shape.points.map(transformPoint)
     if (isPolygon && points.length > 0) points.push(points[0])
-    return `<schematicpath points={${JSON.stringify(points)}} strokeWidth={${toMillimeters(shape.lineWidth)}} strokeColor=${JSON.stringify(isPolygon ? shape.lineColor : shape.color)}${isPolygon && shape.fillColor !== "none" ? ` isFilled fillColor=${JSON.stringify(shape.fillColor)}` : ""} />`
+    return `<schematicpath points={${JSON.stringify(points)}} strokeColor=${JSON.stringify(isPolygon ? shape.lineColor : shape.color)}${isPolygon && shape.fillColor !== "none" ? ` isFilled fillColor=${JSON.stringify(shape.fillColor)}` : ""} />`
   }
 
   if (shape.type === "PATH") {
     const transformedPath = transformSvgPath(shape.pathData, origin)
     if (!transformedPath) return undefined
-    return `<schematicpath svgPath=${JSON.stringify(transformedPath)} strokeWidth={${shape.strokeWidth}} strokeColor=${JSON.stringify(shape.strokeColor)}${shape.fillColor !== "none" ? ` isFilled fillColor=${JSON.stringify(shape.fillColor)}` : ""} />`
+    return `<schematicpath svgPath=${JSON.stringify(transformedPath)} strokeColor=${JSON.stringify(shape.strokeColor)}${shape.fillColor !== "none" ? ` isFilled fillColor=${JSON.stringify(shape.fillColor)}` : ""} />`
   }
 
   if (shape.type === "ARC") {
     const transformedPath = transformSvgPath(shape.pathData, origin)
     if (!transformedPath) return undefined
-    return `<schematicpath svgPath=${JSON.stringify(transformedPath)} strokeWidth={${toMillimeters(shape.lineWidth)}} strokeColor=${JSON.stringify(shape.color)} />`
+    return `<schematicpath svgPath=${JSON.stringify(transformedPath)} strokeColor=${JSON.stringify(shape.color)} />`
   }
 
   if (shape.type === "TEXT") {

--- a/tests/convert-to-ts/C1046-to-ts-with-stepModel.test.ts
+++ b/tests/convert-to-ts/C1046-to-ts-with-stepModel.test.ts
@@ -31,10 +31,10 @@ it("should include both obj and step cad model urls", async () => {
             <symbol>
               <port name="pin2" pinNumber={2} aliases={["2"]} direction="right" schX={5.08} schY={0} schStemLength={0.762} />
               <port name="pin1" pinNumber={1} aliases={["1"]} direction="left" schX={-5.08} schY={0} schStemLength={0.762} />
-              <schematicpath svgPath="M -4.28752 0.01778 A 1.016 0.9906 0 1 0 -2.26568 0.01524" strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath svgPath="M -2.1336 0.01778 A 1.016 0.9906 0 1 0 -0.11176 0.01778" strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath svgPath="M 0.01778 0.01778 A 1.016 0.9906 0 1 0 2.03962 0.01778" strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath svgPath="M 2.2098 0.01778 A 1.016 0.9906 0 1 0 4.23418 0.01524" strokeWidth={0.254} strokeColor="#880000" />
+              <schematicpath svgPath="M -4.28752 0.01778 A 1.016 0.9906 0 1 0 -2.26568 0.01524" strokeColor="#880000" />
+              <schematicpath svgPath="M -2.1336 0.01778 A 1.016 0.9906 0 1 0 -0.11176 0.01778" strokeColor="#880000" />
+              <schematicpath svgPath="M 0.01778 0.01778 A 1.016 0.9906 0 1 0 2.03962 0.01778" strokeColor="#880000" />
+              <schematicpath svgPath="M 2.2098 0.01778 A 1.016 0.9906 0 1 0 4.23418 0.01524" strokeColor="#880000" />
             </symbol>
           }
           supplierPartNumbers={{

--- a/tests/convert-to-ts/C1046-to-ts.test.ts
+++ b/tests/convert-to-ts/C1046-to-ts.test.ts
@@ -35,10 +35,10 @@ it("should convert C1046 into typescript file", async () => {
             <symbol>
               <port name="pin2" pinNumber={2} aliases={["2"]} direction="right" schX={5.08} schY={0} schStemLength={0.762} />
               <port name="pin1" pinNumber={1} aliases={["1"]} direction="left" schX={-5.08} schY={0} schStemLength={0.762} />
-              <schematicpath svgPath="M -4.28752 0.01778 A 1.016 0.9906 0 1 0 -2.26568 0.01524" strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath svgPath="M -2.1336 0.01778 A 1.016 0.9906 0 1 0 -0.11176 0.01778" strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath svgPath="M 0.01778 0.01778 A 1.016 0.9906 0 1 0 2.03962 0.01778" strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath svgPath="M 2.2098 0.01778 A 1.016 0.9906 0 1 0 4.23418 0.01524" strokeWidth={0.254} strokeColor="#880000" />
+              <schematicpath svgPath="M -4.28752 0.01778 A 1.016 0.9906 0 1 0 -2.26568 0.01524" strokeColor="#880000" />
+              <schematicpath svgPath="M -2.1336 0.01778 A 1.016 0.9906 0 1 0 -0.11176 0.01778" strokeColor="#880000" />
+              <schematicpath svgPath="M 0.01778 0.01778 A 1.016 0.9906 0 1 0 2.03962 0.01778" strokeColor="#880000" />
+              <schematicpath svgPath="M 2.2098 0.01778 A 1.016 0.9906 0 1 0 4.23418 0.01524" strokeColor="#880000" />
             </symbol>
           }
           supplierPartNumbers={{

--- a/tests/convert-to-ts/C113367-to-ts.test.ts
+++ b/tests/convert-to-ts/C113367-to-ts.test.ts
@@ -40,15 +40,15 @@ it("should convert C113367 into typescript file", async () => {
           pinLabels={pinLabels}
           symbol={
             <symbol>
-              <schematicpath points={[{"x":-5.08,"y":-6.35},{"x":5.08,"y":-1.27},{"x":-5.08,"y":3.81},{"x":-5.08,"y":-6.35}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":-4.064,"y":1.27},{"x":-2.54,"y":1.27}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":-4.064,"y":-3.81},{"x":-2.54,"y":-3.81}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":-3.302,"y":-3.048},{"x":-3.302,"y":-4.572}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":0,"y":3.81},{"x":0,"y":1.27}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":0,"y":-3.81},{"x":0,"y":-6.35}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":2.54,"y":-2.54},{"x":5.08,"y":-6.35}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":-3.556,"y":3.048},{"x":-5.08,"y":6.35}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":-3.556,"y":-5.588},{"x":-5.08,"y":-8.89}]} strokeWidth={0.254} strokeColor="#880000" />
+              <schematicpath points={[{"x":-5.08,"y":-6.35},{"x":5.08,"y":-1.27},{"x":-5.08,"y":3.81},{"x":-5.08,"y":-6.35}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":-4.064,"y":1.27},{"x":-2.54,"y":1.27}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":-4.064,"y":-3.81},{"x":-2.54,"y":-3.81}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":-3.302,"y":-3.048},{"x":-3.302,"y":-4.572}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":0,"y":3.81},{"x":0,"y":1.27}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":0,"y":-3.81},{"x":0,"y":-6.35}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":2.54,"y":-2.54},{"x":5.08,"y":-6.35}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":-3.556,"y":3.048},{"x":-5.08,"y":6.35}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":-3.556,"y":-5.588},{"x":-5.08,"y":-8.89}]} strokeColor="#880000" />
               <port name="pin1" pinNumber={1} aliases={["SD"]} direction="left" schX={-10.16} schY={6.35} schStemLength={5.08} />
               <port name="pin2" pinNumber={2} aliases={["IN_NEG"]} direction="left" schX={-10.16} schY={1.27} schStemLength={5.08} />
               <port name="pin3" pinNumber={3} aliases={["IN_POS"]} direction="left" schX={-10.16} schY={-3.81} schStemLength={5.08} />

--- a/tests/convert-to-ts/C18185602-to-ts.test.ts
+++ b/tests/convert-to-ts/C18185602-to-ts.test.ts
@@ -41,11 +41,11 @@ it("should convert C18185602 into typescript file", async () => {
               <port name="pin3" pinNumber={3} aliases={["B"]} direction="right" schX={2.54} schY={-5.08} schStemLength={2.54} />
               <port name="pin2" pinNumber={2} aliases={["C"]} direction="right" schX={2.54} schY={-2.54} schStemLength={2.54} />
               <port name="pin4" pinNumber={4} aliases={["A"]} direction="right" schX={2.54} schY={2.54} schStemLength={2.54} />
-              <schematicpath points={[{"x":0,"y":-5.08},{"x":-6.858,"y":-5.08},{"x":-7.366,"y":-3.81},{"x":-7.874,"y":-5.08}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":0,"y":0},{"x":-2.54,"y":0},{"x":-3.048,"y":1.27},{"x":-3.556,"y":0}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicrect schX={-9.144} schY={-2.54} width={1.016} height={4.064} strokeWidth={0.254} color="#880000" />
-              <schematicpath points={[{"x":0,"y":2.54},{"x":-9.144,"y":2.54},{"x":-9.144,"y":-0.508}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":0,"y":-2.54},{"x":-4.572,"y":-2.54},{"x":-5.08,"y":-1.27},{"x":-5.588,"y":-2.54}]} strokeWidth={0.254} strokeColor="#880000" />
+              <schematicpath points={[{"x":0,"y":-5.08},{"x":-6.858,"y":-5.08},{"x":-7.366,"y":-3.81},{"x":-7.874,"y":-5.08}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":0,"y":0},{"x":-2.54,"y":0},{"x":-3.048,"y":1.27},{"x":-3.556,"y":0}]} strokeColor="#880000" />
+              <schematicrect schX={-9.144} schY={-2.54} width={1.016} height={4.064} color="#880000" />
+              <schematicpath points={[{"x":0,"y":2.54},{"x":-9.144,"y":2.54},{"x":-9.144,"y":-0.508}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":0,"y":-2.54},{"x":-4.572,"y":-2.54},{"x":-5.08,"y":-1.27},{"x":-5.588,"y":-2.54}]} strokeColor="#880000" />
             </symbol>
           }
           supplierPartNumbers={{

--- a/tests/convert-to-ts/C281113-to-ts.test.ts
+++ b/tests/convert-to-ts/C281113-to-ts.test.ts
@@ -35,10 +35,10 @@ it("should convert C281113 into typescript file", async () => {
             <symbol>
               <port name="pin2" pinNumber={2} aliases={["2"]} direction="right" schX={5.08} schY={0} schStemLength={0.762} />
               <port name="pin1" pinNumber={1} aliases={["1"]} direction="left" schX={-5.08} schY={0} schStemLength={0.762} />
-              <schematicpath svgPath="M -4.288282 0.017272 A 1.016 0.9906 0 1 0 -2.265172 0.016256" strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath svgPath="M -2.1336 0.018034 A 1.016 0.9906 0 1 0 -0.11049 0.016764" strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath svgPath="M 0.017018 0.018034 A 1.016 0.9906 0 1 0 2.040128 0.016764" strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath svgPath="M 2.2098 0.017526 A 1.016 0.9906 0 1 0 4.23291 0.016256" strokeWidth={0.254} strokeColor="#880000" />
+              <schematicpath svgPath="M -4.288282 0.017272 A 1.016 0.9906 0 1 0 -2.265172 0.016256" strokeColor="#880000" />
+              <schematicpath svgPath="M -2.1336 0.018034 A 1.016 0.9906 0 1 0 -0.11049 0.016764" strokeColor="#880000" />
+              <schematicpath svgPath="M 0.017018 0.018034 A 1.016 0.9906 0 1 0 2.040128 0.016764" strokeColor="#880000" />
+              <schematicpath svgPath="M 2.2098 0.017526 A 1.016 0.9906 0 1 0 4.23291 0.016256" strokeColor="#880000" />
             </symbol>
           }
           supplierPartNumbers={{

--- a/tests/convert-to-ts/C2961147-to-ts.test.ts
+++ b/tests/convert-to-ts/C2961147-to-ts.test.ts
@@ -51,14 +51,14 @@ it("should convert C2961147 into typescript file", async () => {
               <port name="pin3" pinNumber={3} aliases={["3"]} direction="right" schX={7.62} schY={0} schStemLength={5.08} />
               <port name="pin2" pinNumber={2} aliases={["2"]} direction="right" schX={7.62} schY={-2.54} schStemLength={5.08} />
               <port name="pin1" pinNumber={1} aliases={["1"]} direction="right" schX={7.62} schY={2.54} schStemLength={5.08} />
-              <schematicpath points={[{"x":-1.778,"y":-2.54},{"x":-1.524,"y":-1.27}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":2.54,"y":0},{"x":-1.778,"y":0},{"x":-1.778,"y":-2.54},{"x":-2.032,"y":-1.27}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":2.54,"y":-2.54},{"x":-4.826,"y":-2.54},{"x":-5.334,"y":-1.524},{"x":-5.842,"y":-2.54}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath svgPath="M -5.08 1.524 A 1.016 1.016 0 1 0 -5.08 3.556" strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":0,"y":1.524},{"x":-5.08,"y":1.524}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":0,"y":3.556},{"x":-5.08,"y":3.556}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicrect schX={0.508} schY={2.54} width={1.016} height={3.048} strokeWidth={0.254} color="#880000" />
-              <schematicpath points={[{"x":2.54,"y":2.54},{"x":1.016,"y":2.54}]} strokeWidth={0.254} strokeColor="#880000" />
+              <schematicpath points={[{"x":-1.778,"y":-2.54},{"x":-1.524,"y":-1.27}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":2.54,"y":0},{"x":-1.778,"y":0},{"x":-1.778,"y":-2.54},{"x":-2.032,"y":-1.27}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":2.54,"y":-2.54},{"x":-4.826,"y":-2.54},{"x":-5.334,"y":-1.524},{"x":-5.842,"y":-2.54}]} strokeColor="#880000" />
+              <schematicpath svgPath="M -5.08 1.524 A 1.016 1.016 0 1 0 -5.08 3.556" strokeColor="#880000" />
+              <schematicpath points={[{"x":0,"y":1.524},{"x":-5.08,"y":1.524}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":0,"y":3.556},{"x":-5.08,"y":3.556}]} strokeColor="#880000" />
+              <schematicrect schX={0.508} schY={2.54} width={1.016} height={3.048} color="#880000" />
+              <schematicpath points={[{"x":2.54,"y":2.54},{"x":1.016,"y":2.54}]} strokeColor="#880000" />
             </symbol>
           }
           supplierPartNumbers={{

--- a/tests/convert-to-ts/C2998002-to-ts.test.ts
+++ b/tests/convert-to-ts/C2998002-to-ts.test.ts
@@ -37,20 +37,20 @@ it("should convert C2998002 into typescript file", async () => {
             <symbol>
               <schematictext schX={3.81} schY={-0.762} text="TR1" fontSize={1.940278} anchor="left" color="#0000FF" schRotation={0} />
               <schematictext schX={-7.366} schY={-0.762} text="TR2" fontSize={1.940278} anchor="left" color="#0000FF" schRotation={0} />
-              <schematiccircle center={{ x: 0, y: 0 }} radius={0.127} strokeWidth={0.254} color="#880000" />
-              <schematicrect schX={0} schY={0} width={15.24} height={5.08} strokeWidth={0.254} color="#880000" />
-              <schematicpath points={[{"x":0,"y":0},{"x":0,"y":-1.778},{"x":-5.08,"y":-1.778}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":2.54,"y":-0.762},{"x":5.08,"y":-1.778},{"x":5.08,"y":-2.54}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":-2.54,"y":-0.762},{"x":-5.08,"y":-1.778},{"x":-5.08,"y":-2.54}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":-2.54,"y":0.508},{"x":-3.302,"y":0.508}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":-2.54,"y":0.508},{"x":-3.048,"y":1.016}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":2.54,"y":0.508},{"x":3.048,"y":1.016}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":2.54,"y":0.508},{"x":3.302,"y":0.508}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":2.54,"y":0.508},{"x":5.08,"y":1.524},{"x":5.08,"y":2.54}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":-2.54,"y":0.508},{"x":-5.08,"y":1.524},{"x":-5.08,"y":2.54}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":-2.54,"y":0},{"x":2.54,"y":0}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":2.54,"y":1.27},{"x":2.54,"y":-1.27}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":-2.54,"y":1.27},{"x":-2.54,"y":-1.27}]} strokeWidth={0.254} strokeColor="#880000" />
+              <schematiccircle center={{ x: 0, y: 0 }} radius={0.127} color="#880000" />
+              <schematicrect schX={0} schY={0} width={15.24} height={5.08} color="#880000" />
+              <schematicpath points={[{"x":0,"y":0},{"x":0,"y":-1.778},{"x":-5.08,"y":-1.778}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":2.54,"y":-0.762},{"x":5.08,"y":-1.778},{"x":5.08,"y":-2.54}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":-2.54,"y":-0.762},{"x":-5.08,"y":-1.778},{"x":-5.08,"y":-2.54}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":-2.54,"y":0.508},{"x":-3.302,"y":0.508}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":-2.54,"y":0.508},{"x":-3.048,"y":1.016}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":2.54,"y":0.508},{"x":3.048,"y":1.016}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":2.54,"y":0.508},{"x":3.302,"y":0.508}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":2.54,"y":0.508},{"x":5.08,"y":1.524},{"x":5.08,"y":2.54}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":-2.54,"y":0.508},{"x":-5.08,"y":1.524},{"x":-5.08,"y":2.54}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":-2.54,"y":0},{"x":2.54,"y":0}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":2.54,"y":1.27},{"x":2.54,"y":-1.27}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":-2.54,"y":1.27},{"x":-2.54,"y":-1.27}]} strokeColor="#880000" />
               <port name="pin3" pinNumber={3} aliases={["E1","E"]} direction="up" schX={5.08} schY={5.08} schStemLength={2.54} />
               <port name="pin1" pinNumber={1} aliases={["C1","C"]} direction="down" schX={-5.08} schY={-5.08} schStemLength={2.54} />
               <port name="pin2" pinNumber={2} aliases={["C2","C"]} direction="down" schX={5.08} schY={-5.08} schStemLength={2.54} />

--- a/tests/convert-to-ts/C309274-to-ts.test.ts
+++ b/tests/convert-to-ts/C309274-to-ts.test.ts
@@ -39,23 +39,23 @@ it("should convert C309274 into typescript file", async () => {
           pinLabels={pinLabels}
           symbol={
             <symbol>
-              <schematicrect schX={-5.842} schY={1.27} width={1.524} height={7.62} strokeWidth={0.254} color="#880000" />
-              <schematicpath points={[{"x":5.08,"y":5.08},{"x":2.54,"y":5.08},{"x":2.54,"y":7.62},{"x":2.794,"y":6.096}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":2.54,"y":7.62},{"x":2.286,"y":6.096}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":5.08,"y":0},{"x":2.54,"y":0},{"x":2.54,"y":2.54},{"x":2.286,"y":1.27}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":2.54,"y":2.54},{"x":2.794,"y":1.27}]} strokeWidth={0.254} strokeColor="#880000" />
+              <schematicrect schX={-5.842} schY={1.27} width={1.524} height={7.62} color="#880000" />
+              <schematicpath points={[{"x":5.08,"y":5.08},{"x":2.54,"y":5.08},{"x":2.54,"y":7.62},{"x":2.794,"y":6.096}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":2.54,"y":7.62},{"x":2.286,"y":6.096}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":5.08,"y":0},{"x":2.54,"y":0},{"x":2.54,"y":2.54},{"x":2.286,"y":1.27}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":2.54,"y":2.54},{"x":2.794,"y":1.27}]} strokeColor="#880000" />
               <port name="pin2" pinNumber={2} aliases={["2"]} direction="right" schX={7.62} schY={7.62} schStemLength={2.54} />
               <port name="pin3" pinNumber={3} aliases={["3"]} direction="right" schX={7.62} schY={5.08} schStemLength={2.54} />
               <port name="pin4" pinNumber={4} aliases={["4"]} direction="right" schX={7.62} schY={2.54} schStemLength={2.54} />
               <port name="pin5" pinNumber={5} aliases={["5"]} direction="right" schX={7.62} schY={0} schStemLength={2.54} />
               <port name="pin6" pinNumber={6} aliases={["6"]} direction="right" schX={7.62} schY={-2.54} schStemLength={2.54} />
               <port name="pin7" pinNumber={7} aliases={["7"]} direction="right" schX={7.62} schY={-5.08} schStemLength={2.54} />
-              <schematicpath points={[{"x":5.08,"y":7.62},{"x":-2.54,"y":7.62},{"x":-2.54,"y":2.54}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath svgPath="M -3.556 2.54 C -3.556 1.778 -2.54 1.778 -2.54 2.54" strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":5.08,"y":-5.08},{"x":2.54,"y":-5.08},{"x":2.54,"y":-2.54},{"x":2.286,"y":-3.81}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":2.54,"y":-2.54},{"x":2.794,"y":-3.81}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":5.08,"y":2.54},{"x":0.508,"y":2.54},{"x":0,"y":3.556},{"x":-0.508,"y":2.54}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":5.08,"y":-2.54},{"x":1.778,"y":-2.54},{"x":1.27,"y":-1.524},{"x":0.762,"y":-2.54}]} strokeWidth={0.254} strokeColor="#880000" />
+              <schematicpath points={[{"x":5.08,"y":7.62},{"x":-2.54,"y":7.62},{"x":-2.54,"y":2.54}]} strokeColor="#880000" />
+              <schematicpath svgPath="M -3.556 2.54 C -3.556 1.778 -2.54 1.778 -2.54 2.54" strokeColor="#880000" />
+              <schematicpath points={[{"x":5.08,"y":-5.08},{"x":2.54,"y":-5.08},{"x":2.54,"y":-2.54},{"x":2.286,"y":-3.81}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":2.54,"y":-2.54},{"x":2.794,"y":-3.81}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":5.08,"y":2.54},{"x":0.508,"y":2.54},{"x":0,"y":3.556},{"x":-0.508,"y":2.54}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":5.08,"y":-2.54},{"x":1.778,"y":-2.54},{"x":1.27,"y":-1.524},{"x":0.762,"y":-2.54}]} strokeColor="#880000" />
             </symbol>
           }
           supplierPartNumbers={{

--- a/tests/convert-to-ts/C5830143-to-ts.test.ts
+++ b/tests/convert-to-ts/C5830143-to-ts.test.ts
@@ -37,20 +37,20 @@ it("should convert C5830143 into typescript file", async () => {
           symbol={
             <symbol>
               <port name="pin2" pinNumber={2} aliases={["2"]} direction="up" schX={0} schY={2.794} schStemLength={2.54} />
-              <schematiccircle center={{ x: 2.794, y: -1.524 }} radius={0.254} strokeWidth={0.254} color="#A00000" />
-              <schematicpath points={[{"x":-0.508,"y":0.254},{"x":0,"y":-0.762},{"x":0.508,"y":0.254},{"x":-0.508,"y":0.254}]} strokeWidth={0.254} strokeColor="#880000" />
+              <schematiccircle center={{ x: 2.794, y: -1.524 }} radius={0.254} color="#A00000" />
+              <schematicpath points={[{"x":-0.508,"y":0.254},{"x":0,"y":-0.762},{"x":0.508,"y":0.254},{"x":-0.508,"y":0.254}]} strokeColor="#880000" />
               <port name="pin1" pinNumber={1} aliases={["1"]} direction="right" schX={5.08} schY={-2.286} schStemLength={2.54} />
               <port name="pin3" pinNumber={3} aliases={["3"]} direction="left" schX={-5.08} schY={-2.286} schStemLength={2.54} />
-              <schematicpath points={[{"x":0,"y":0.254},{"x":0,"y":-0.762}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":2.286,"y":-3.302},{"x":2.54,"y":-2.286}]} strokeWidth={0.254} strokeColor="#8D2323" />
-              <schematicpath points={[{"x":1.524,"y":-1.27},{"x":2.286,"y":-3.302}]} strokeWidth={0.254} strokeColor="#8D2323" />
-              <schematicpath points={[{"x":1.016,"y":-3.302},{"x":1.524,"y":-1.27}]} strokeWidth={0.254} strokeColor="#8D2323" />
-              <schematicpath points={[{"x":0.254,"y":-1.27},{"x":1.016,"y":-3.302}]} strokeWidth={0.254} strokeColor="#8D2323" />
-              <schematicpath points={[{"x":-0.254,"y":-3.302},{"x":0.254,"y":-1.27}]} strokeWidth={0.254} strokeColor="#8D2323" />
-              <schematicpath points={[{"x":-0.762,"y":-1.27},{"x":-0.254,"y":-3.302}]} strokeWidth={0.254} strokeColor="#8D2323" />
-              <schematicpath points={[{"x":-1.524,"y":-3.302},{"x":-0.762,"y":-1.27}]} strokeWidth={0.254} strokeColor="#8D2323" />
-              <schematicpath points={[{"x":-2.032,"y":-1.27},{"x":-1.524,"y":-3.302}]} strokeWidth={0.254} strokeColor="#8D2323" />
-              <schematicpath points={[{"x":-2.54,"y":-2.286},{"x":-2.032,"y":-1.27}]} strokeWidth={0.254} strokeColor="#8D2323" />
+              <schematicpath points={[{"x":0,"y":0.254},{"x":0,"y":-0.762}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":2.286,"y":-3.302},{"x":2.54,"y":-2.286}]} strokeColor="#8D2323" />
+              <schematicpath points={[{"x":1.524,"y":-1.27},{"x":2.286,"y":-3.302}]} strokeColor="#8D2323" />
+              <schematicpath points={[{"x":1.016,"y":-3.302},{"x":1.524,"y":-1.27}]} strokeColor="#8D2323" />
+              <schematicpath points={[{"x":0.254,"y":-1.27},{"x":1.016,"y":-3.302}]} strokeColor="#8D2323" />
+              <schematicpath points={[{"x":-0.254,"y":-3.302},{"x":0.254,"y":-1.27}]} strokeColor="#8D2323" />
+              <schematicpath points={[{"x":-0.762,"y":-1.27},{"x":-0.254,"y":-3.302}]} strokeColor="#8D2323" />
+              <schematicpath points={[{"x":-1.524,"y":-3.302},{"x":-0.762,"y":-1.27}]} strokeColor="#8D2323" />
+              <schematicpath points={[{"x":-2.032,"y":-1.27},{"x":-1.524,"y":-3.302}]} strokeColor="#8D2323" />
+              <schematicpath points={[{"x":-2.54,"y":-2.286},{"x":-2.032,"y":-1.27}]} strokeColor="#8D2323" />
             </symbol>
           }
           supplierPartNumbers={{

--- a/tests/convert-to-ts/C75749-to-ts.test.ts
+++ b/tests/convert-to-ts/C75749-to-ts.test.ts
@@ -44,24 +44,24 @@ it("should convert C75749 into typescript file", async () => {
           pinLabels={pinLabels}
           symbol={
             <symbol>
-              <schematicpath points={[{"x":-5.08,"y":-2.032},{"x":-5.08,"y":-3.81}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":-10.16,"y":-2.032},{"x":-10.16,"y":-3.81}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":0,"y":-2.032},{"x":0,"y":-3.81}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":-7.62,"y":-3.81},{"x":-7.62,"y":0.508}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":5.08,"y":-2.032},{"x":5.08,"y":-3.81}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":-2.54,"y":-3.81},{"x":-2.54,"y":0.508}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":10.16,"y":-2.032},{"x":10.16,"y":-3.81}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":2.54,"y":-3.81},{"x":2.54,"y":0.508}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":7.62,"y":-3.81},{"x":7.62,"y":0.508}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematiccircle center={{ x: 7.62, y: 1.27 }} radius={0.762} strokeWidth={0.254} color="#880000" />
-              <schematiccircle center={{ x: 2.54, y: 1.27 }} radius={0.762} strokeWidth={0.254} color="#880000" />
-              <schematiccircle center={{ x: -2.54, y: 1.27 }} radius={0.762} strokeWidth={0.254} color="#880000" />
-              <schematiccircle center={{ x: -7.62, y: 1.27 }} radius={0.762} strokeWidth={0.254} color="#880000" />
-              <schematiccircle center={{ x: 10.16, y: -1.27 }} radius={0.762} strokeWidth={0.254} color="#880000" />
-              <schematiccircle center={{ x: 5.08, y: -1.27 }} radius={0.762} strokeWidth={0.254} color="#880000" />
-              <schematiccircle center={{ x: 0, y: -1.27 }} radius={0.762} strokeWidth={0.254} color="#880000" />
-              <schematiccircle center={{ x: -5.08, y: -1.27 }} radius={0.762} strokeWidth={0.254} color="#880000" />
-              <schematiccircle center={{ x: -10.16, y: -1.27 }} radius={0.762} strokeWidth={0.254} color="#880000" />
+              <schematicpath points={[{"x":-5.08,"y":-2.032},{"x":-5.08,"y":-3.81}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":-10.16,"y":-2.032},{"x":-10.16,"y":-3.81}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":0,"y":-2.032},{"x":0,"y":-3.81}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":-7.62,"y":-3.81},{"x":-7.62,"y":0.508}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":5.08,"y":-2.032},{"x":5.08,"y":-3.81}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":-2.54,"y":-3.81},{"x":-2.54,"y":0.508}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":10.16,"y":-2.032},{"x":10.16,"y":-3.81}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":2.54,"y":-3.81},{"x":2.54,"y":0.508}]} strokeColor="#880000" />
+              <schematicpath points={[{"x":7.62,"y":-3.81},{"x":7.62,"y":0.508}]} strokeColor="#880000" />
+              <schematiccircle center={{ x: 7.62, y: 1.27 }} radius={0.762} color="#880000" />
+              <schematiccircle center={{ x: 2.54, y: 1.27 }} radius={0.762} color="#880000" />
+              <schematiccircle center={{ x: -2.54, y: 1.27 }} radius={0.762} color="#880000" />
+              <schematiccircle center={{ x: -7.62, y: 1.27 }} radius={0.762} color="#880000" />
+              <schematiccircle center={{ x: 10.16, y: -1.27 }} radius={0.762} color="#880000" />
+              <schematiccircle center={{ x: 5.08, y: -1.27 }} radius={0.762} color="#880000" />
+              <schematiccircle center={{ x: 0, y: -1.27 }} radius={0.762} color="#880000" />
+              <schematiccircle center={{ x: -5.08, y: -1.27 }} radius={0.762} color="#880000" />
+              <schematiccircle center={{ x: -10.16, y: -1.27 }} radius={0.762} color="#880000" />
               <port name="pin1" pinNumber={1} aliases={["1"]} direction="down" schX={-10.16} schY={-8.89} schStemLength={5.08} />
               <port name="pin2" pinNumber={2} aliases={["2"]} direction="down" schX={-5.08} schY={-8.89} schStemLength={5.08} />
               <port name="pin3" pinNumber={3} aliases={["3"]} direction="down" schX={0} schY={-8.89} schStemLength={5.08} />
@@ -71,18 +71,18 @@ it("should convert C75749 into typescript file", async () => {
               <port name="pin7" pinNumber={7} aliases={["7"]} direction="down" schX={-2.54} schY={-8.89} schStemLength={5.08} />
               <port name="pin8" pinNumber={8} aliases={["8"]} direction="down" schX={2.54} schY={-8.89} schStemLength={5.08} />
               <port name="pin9" pinNumber={9} aliases={["9"]} direction="down" schX={7.62} schY={-8.89} schStemLength={5.08} />
-              <schematicpath points={[{"x":10.16,"y":-3.81},{"x":-10.16,"y":-3.81}]} strokeWidth={0.254} strokeColor="#880000" />
+              <schematicpath points={[{"x":10.16,"y":-3.81},{"x":-10.16,"y":-3.81}]} strokeColor="#880000" />
               <port name="pin11" pinNumber={11} aliases={["MH2"]} direction="up" schX={-5.08} schY={8.89} schStemLength={5.08} />
               <port name="pin10" pinNumber={10} aliases={["MH1"]} direction="up" schX={5.08} schY={8.89} schStemLength={5.08} />
-              <schematicpath points={[{"x":10.16,"y":3.81},{"x":-10.16,"y":3.81}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath svgPath="M -10.16 3.81 A 1.27 1.27 0 0 1 -11.3808 2.890063" strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":-11.938,"y":-3.81},{"x":-10.16,"y":-3.81}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath svgPath="M -12.645796 -2.417648 A 0.762 1.016 0 0 1 -11.84971 -3.803167" strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":-11.43,"y":2.794},{"x":-12.7,"y":-2.54}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath svgPath="M 11.386718 2.868701 A 1.27 1.27 0 0 1 10.16 3.81" strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":11.938,"y":-3.81},{"x":10.16,"y":-3.81}]} strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath svgPath="M 11.84971 -3.803167 A 0.762 1.016 0 0 1 12.645796 -2.417648" strokeWidth={0.254} strokeColor="#880000" />
-              <schematicpath points={[{"x":11.43,"y":2.794},{"x":12.7,"y":-2.54}]} strokeWidth={0.254} strokeColor="#880000" />
+              <schematicpath points={[{"x":10.16,"y":3.81},{"x":-10.16,"y":3.81}]} strokeColor="#880000" />
+              <schematicpath svgPath="M -10.16 3.81 A 1.27 1.27 0 0 1 -11.3808 2.890063" strokeColor="#880000" />
+              <schematicpath points={[{"x":-11.938,"y":-3.81},{"x":-10.16,"y":-3.81}]} strokeColor="#880000" />
+              <schematicpath svgPath="M -12.645796 -2.417648 A 0.762 1.016 0 0 1 -11.84971 -3.803167" strokeColor="#880000" />
+              <schematicpath points={[{"x":-11.43,"y":2.794},{"x":-12.7,"y":-2.54}]} strokeColor="#880000" />
+              <schematicpath svgPath="M 11.386718 2.868701 A 1.27 1.27 0 0 1 10.16 3.81" strokeColor="#880000" />
+              <schematicpath points={[{"x":11.938,"y":-3.81},{"x":10.16,"y":-3.81}]} strokeColor="#880000" />
+              <schematicpath svgPath="M 11.84971 -3.803167 A 0.762 1.016 0 0 1 12.645796 -2.417648" strokeColor="#880000" />
+              <schematicpath points={[{"x":11.43,"y":2.794},{"x":12.7,"y":-2.54}]} strokeColor="#880000" />
             </symbol>
           }
           supplierPartNumbers={{

--- a/tests/generate-symbol-tsx.test.ts
+++ b/tests/generate-symbol-tsx.test.ts
@@ -34,12 +34,17 @@ test("generates a centered symbol with positioned, aliased ports", () => {
 })
 
 test("transforms EasyEDA paths, arcs, and text into symbol-local coordinates", () => {
-  expect(generateSymbolFromRawEasy(symbolWithPathRawEasy)).toContain(
-    '<schematicpath svgPath="M 1.27 1.778 L -1.27 0 L 1.27 -1.778 Z" strokeWidth={0.254} strokeColor="#880000" />',
+  const pathSymbolTsx = generateSymbolFromRawEasy(symbolWithPathRawEasy)
+  const arcSymbolTsx = generateSymbolFromRawEasy(symbolWithArcRawEasy)
+
+  expect(pathSymbolTsx).toContain(
+    '<schematicpath svgPath="M 1.27 1.778 L -1.27 0 L 1.27 -1.778 Z" strokeColor="#880000" />',
   )
-  expect(generateSymbolFromRawEasy(symbolWithArcRawEasy)).toContain(
-    '<schematicpath svgPath="M -5.08 1.524 A 1.016 1.016 0 1 0 -5.08 3.556" strokeWidth={0.254} strokeColor="#880000" />',
+  expect(arcSymbolTsx).toContain(
+    '<schematicpath svgPath="M -5.08 1.524 A 1.016 1.016 0 1 0 -5.08 3.556" strokeColor="#880000" />',
   )
+  expect(pathSymbolTsx).not.toContain("strokeWidth")
+  expect(arcSymbolTsx).not.toContain("strokeWidth")
   expect(generateSymbolFromRawEasy(rp2040RawEasy)).toContain(
     '<schematictext schX={0} schY={2.54} text="RP2040" fontSize={4.056944} anchor="left" color="#0000FF" schRotation={0} />',
   )


### PR DESCRIPTION
## Summary

- omit `strokeWidth` from generated EasyEDA schematic rectangles, circles, polylines, polygons, paths, and arcs
- update the affected inline snapshots
- preserve the existing chip-box symbol classification logic unchanged

## Why

Generated symbol elements should rely on the tscircuit primitives' default stroke width rather than copying EasyEDA stroke widths into the TSX.

## Impact

Imported custom EasyEDA symbols no longer emit a `strokeWidth` property. Which parts receive a `symbol` prop is unchanged.

## Validation

- affected converter tests: 15 passed, 0 failed
- `bun run build`
- `bun run format:check`
