### PR TITLE
Reject fuzzy EasyEDA component matches

### DIFF
--- a/lib/websafe/fetch-easyeda-json.ts
+++ b/lib/websafe/fetch-easyeda-json.ts
@@ -122,11 +122,28 @@ export async function fetchEasyEDAComponent(
     throw new Error("Component not found")
   }
 
-  const bestMatchComponent =
-    searchResult.result.lists.lcsc.find(
-      (component: any) =>
-        component.dataStr.head.c_para["Supplier Part"] === jlcpcbPartNumber,
-    ) ?? searchResult.result.lists.lcsc[0]
+  const requestedPartNumber = jlcpcbPartNumber.trim().toUpperCase()
+  const bestMatchComponent = searchResult.result.lists.lcsc.find(
+    (component: any) => {
+      const candidatePartNumbers = [
+        component.dataStr?.head?.c_para?.["Supplier Part"],
+        component.lcsc?.number,
+        component.szlcsc?.number,
+      ]
+
+      return candidatePartNumbers.some(
+        (partNumber) =>
+          typeof partNumber === "string" &&
+          partNumber.trim().toUpperCase() === requestedPartNumber,
+      )
+    },
+  )
+
+  if (!bestMatchComponent) {
+    throw new Error(
+      `No exact EasyEDA component match for "${jlcpcbPartNumber}"`,
+    )
+  }
 
   const componentUUID = bestMatchComponent.uuid
 

--- a/tests/fetch-tests/c1555-0402-repro.test.ts
+++ b/tests/fetch-tests/c1555-0402-repro.test.ts
@@ -99,7 +99,7 @@ const misleadingDetailResult = {
   },
 }
 
-it("reproduces C1555 resolving to a non-0402 value match", async () => {
+it("rejects C1555 when EasyEDA only returns fuzzy value matches", async () => {
   const requests: string[] = []
   const fakeFetchImplementation = async (
     input: RequestInfo | URL,
@@ -148,17 +148,19 @@ it("reproduces C1555 resolving to a non-0402 value match", async () => {
     preconnect: globalThis.fetch.preconnect,
   })
 
-  const result = await fetchEasyEDAComponent("C1555", {
-    fetch: fakeFetch,
-    includeModelMetadata: false,
-  })
+  await expect(
+    fetchEasyEDAComponent("C1555", {
+      fetch: fakeFetch,
+      includeModelMetadata: false,
+    }),
+  ).rejects.toThrow('No exact EasyEDA component match for "C1555"')
 
-  expect(requests).toHaveLength(2)
-  expect(result.dataStr.head.c_para["Supplier Part"]).toBe("C6083536")
-  expect(result.lcsc.number).toBe("C6083536")
-  expect(result.dataStr.head.c_para.package).toContain("OSC-SMD_6P")
+  // The misleading result must not be followed to the component-details API.
+  expect(requests).toHaveLength(1)
+})
 
-  const betterResult = EasyEdaJsonSchema.parse(result)
+it("snapshots the misleading C1555 search candidate", () => {
+  const betterResult = EasyEdaJsonSchema.parse(misleadingDetailResult)
   const circuitJson = convertEasyEdaJsonToCircuitJson(betterResult, {
     useModelCdn: false,
   })


### PR DESCRIPTION
## What changed

- Require an exact EasyEDA supplier-part or LCSC number match before fetching component details.
- Accept exact matches from the search result's `Supplier Part`, `lcsc.number`, or `szlcsc.number` fields.
- Reject fuzzy-only searches instead of silently selecting the first result.
- Turn the merged C1555 reproduction into a correctness test while retaining its SVG snapshot of the misleading oscillator candidate.

## Why

EasyEDA currently returns `C6083536` (a six-pin oscillator) as the first fuzzy result for `C1555`, while the design expects a 0402 capacitor. The previous fallback fetched that footprint and produced a 0.1081 copper IoU mismatch. `C1555` has no exact result in the search response, so the converter should fail clearly rather than return an unrelated footprint.

## Validation

- `bun test` (131 passed, 0 failed)
- `bun run build`
- `bun run format:check`
- `bunx tsc --noEmit`
- Live lookup of `C1555` now fails with `No exact EasyEDA component match for "C1555"`
