### PR TITLE
Keep LED driver ICs as chips

### DIFF
--- a/lib/websafe/convert-to-typescript-component/category-value-contains-led.ts
+++ b/lib/websafe/convert-to-typescript-component/category-value-contains-led.ts
@@ -1,5 +1,7 @@
 export const categoryValueContainsLed = (value: unknown): boolean => {
   if (typeof value === "string") {
+    if (/(^|[^a-z])leds?\s+drivers?([^a-z]|$)/i.test(value)) return false
+
     return (
       /(^|[^a-z])leds?([^a-z]|$)/i.test(value) ||
       /light[-\s]?emitting\s+diodes?/i.test(value)

--- a/tests/convert-to-ts/c82173-to-ts.test.ts
+++ b/tests/convert-to-ts/c82173-to-ts.test.ts
@@ -3,10 +3,11 @@ import { EasyEdaJsonSchema } from "lib/schemas/easy-eda-json-schema"
 import { convertBetterEasyToTsx } from "lib/websafe/convert-to-typescript-component"
 import chipRawEasy from "../assets/C82173.raweasy.json"
 
-it("reproduces C82173 being generated as a discrete LED", async () => {
+it("generates the C82173 LED driver IC as a chip", async () => {
   const betterEasy = EasyEdaJsonSchema.parse(chipRawEasy)
   const result = await convertBetterEasyToTsx({ betterEasy })
 
-  expect(result).toContain('import type { LedProps } from "@tscircuit/props"')
-  expect(result).toContain("<led")
+  expect(result).toContain('import type { ChipProps } from "@tscircuit/props"')
+  expect(result).toContain("<chip")
+  expect(result).not.toContain("<led")
 })


### PR DESCRIPTION
## Summary

- stack base: #430
- keep `LED Driver` and `LED Drivers` categories out of the discrete-LED classifier
- update the C82173 reproduction to require `ChipProps` and `<chip>` output
- retain existing discrete LED behavior

## Root cause

`categoryValueContainsLed` matched the standalone `LED` token inside the category `LED Drivers`. That category describes an integrated driver circuit, not an LED component.

The fix adds one category guard before the existing LED checks. No component-specific override or pin-count heuristic is introduced.

## Validation

- full network-enabled suite: 136 passed, 0 failed, 56 snapshots
- `bun test ./tests/convert-to-ts/c82173-to-ts.test.ts ./tests/convert-to-ts/C57759-to-led.test.ts --timeout 60000`
- `bun run format:check`
- `bun run build`
