### PR TITLE
Preserve exact manufacturer part numbers

### DIFF
--- a/lib/websafe/convert-to-typescript-component/generate-typescript-component.ts
+++ b/lib/websafe/convert-to-typescript-component/generate-typescript-component.ts
@@ -17,7 +17,7 @@ interface Params {
   stepUrl?: string
   circuitJson: AnyCircuitElement[]
   supplierPartNumbers: SupplierPartNumbers
-  manufacturerPartNumber: string | null
+  manufacturerPartNumber: string
   componentType?: GeneratedComponentType
   symbolTsx?: string
 }
@@ -83,10 +83,6 @@ ${symbolTsx
       }
 `
     : ""
-  const manufacturerPartNumberProp = manufacturerPartNumber
-    ? `      manufacturerPartNumber=${JSON.stringify(manufacturerPartNumber)}
-`
-    : ""
 
   const cadModelLines = [
     objUrl ? `objUrl: "${objUrl}",` : "",
@@ -112,7 +108,7 @@ export const ${componentName} = (props: DiodeProps) => {
 ${polarizedPinLabelsProp}\
 ${symbolProp}\
       supplierPartNumbers={${JSON.stringify(supplierPartNumbers, null, "  ")}}
-${manufacturerPartNumberProp}\
+      manufacturerPartNumber="${manufacturerPartNumber}"
       footprint={${footprintTsx}}
       ${
         objUrl || stepUrl
@@ -142,7 +138,7 @@ export const ${componentName} = (props: LedProps) => {
 ${polarizedPinLabelsProp}\
 ${symbolProp}\
       supplierPartNumbers={${JSON.stringify(supplierPartNumbers, null, "  ")}}
-${manufacturerPartNumberProp}\
+      manufacturerPartNumber="${manufacturerPartNumber}"
       footprint={${footprintTsx}}
       ${
         objUrl || stepUrl
@@ -175,7 +171,7 @@ export const ${componentName} = (props: PushButtonProps<typeof pinLabels>) => {
       pinLabels={pinLabels}
 ${symbolProp}\
       supplierPartNumbers={${JSON.stringify(supplierPartNumbers, null, "  ")}}
-${manufacturerPartNumberProp}\
+      manufacturerPartNumber="${manufacturerPartNumber}"
       footprint={${footprintTsx}}
       ${
         objUrl || stepUrl
@@ -208,7 +204,7 @@ export const ${componentName} = (props: SwitchProps) => {
       pinLabels={pinLabels}
 ${symbolProp}\
       supplierPartNumbers={${JSON.stringify(supplierPartNumbers, null, "  ")}}
-${manufacturerPartNumberProp}\
+      manufacturerPartNumber="${manufacturerPartNumber}"
       footprint={${footprintTsx}}
       ${
         objUrl || stepUrl
@@ -237,7 +233,7 @@ export const ${componentName} = (props: ChipProps<typeof pinLabels>) => {
       pinLabels={pinLabels}
 ${symbolProp}\
       supplierPartNumbers={${JSON.stringify(supplierPartNumbers, null, "  ")}}
-${manufacturerPartNumberProp}\
+      manufacturerPartNumber="${manufacturerPartNumber}"
       footprint={${footprintTsx}}
       ${
         objUrl || stepUrl

--- a/lib/websafe/convert-to-typescript-component/generate-typescript-component.ts
+++ b/lib/websafe/convert-to-typescript-component/generate-typescript-component.ts
@@ -17,7 +17,7 @@ interface Params {
   stepUrl?: string
   circuitJson: AnyCircuitElement[]
   supplierPartNumbers: SupplierPartNumbers
-  manufacturerPartNumber: string
+  manufacturerPartNumber: string | null
   componentType?: GeneratedComponentType
   symbolTsx?: string
 }
@@ -83,6 +83,10 @@ ${symbolTsx
       }
 `
     : ""
+  const manufacturerPartNumberProp = manufacturerPartNumber
+    ? `      manufacturerPartNumber=${JSON.stringify(manufacturerPartNumber)}
+`
+    : ""
 
   const cadModelLines = [
     objUrl ? `objUrl: "${objUrl}",` : "",
@@ -108,7 +112,7 @@ export const ${componentName} = (props: DiodeProps) => {
 ${polarizedPinLabelsProp}\
 ${symbolProp}\
       supplierPartNumbers={${JSON.stringify(supplierPartNumbers, null, "  ")}}
-      manufacturerPartNumber="${manufacturerPartNumber}"
+${manufacturerPartNumberProp}\
       footprint={${footprintTsx}}
       ${
         objUrl || stepUrl
@@ -138,7 +142,7 @@ export const ${componentName} = (props: LedProps) => {
 ${polarizedPinLabelsProp}\
 ${symbolProp}\
       supplierPartNumbers={${JSON.stringify(supplierPartNumbers, null, "  ")}}
-      manufacturerPartNumber="${manufacturerPartNumber}"
+${manufacturerPartNumberProp}\
       footprint={${footprintTsx}}
       ${
         objUrl || stepUrl
@@ -171,7 +175,7 @@ export const ${componentName} = (props: PushButtonProps<typeof pinLabels>) => {
       pinLabels={pinLabels}
 ${symbolProp}\
       supplierPartNumbers={${JSON.stringify(supplierPartNumbers, null, "  ")}}
-      manufacturerPartNumber="${manufacturerPartNumber}"
+${manufacturerPartNumberProp}\
       footprint={${footprintTsx}}
       ${
         objUrl || stepUrl
@@ -204,7 +208,7 @@ export const ${componentName} = (props: SwitchProps) => {
       pinLabels={pinLabels}
 ${symbolProp}\
       supplierPartNumbers={${JSON.stringify(supplierPartNumbers, null, "  ")}}
-      manufacturerPartNumber="${manufacturerPartNumber}"
+${manufacturerPartNumberProp}\
       footprint={${footprintTsx}}
       ${
         objUrl || stepUrl
@@ -233,7 +237,7 @@ export const ${componentName} = (props: ChipProps<typeof pinLabels>) => {
       pinLabels={pinLabels}
 ${symbolProp}\
       supplierPartNumbers={${JSON.stringify(supplierPartNumbers, null, "  ")}}
-      manufacturerPartNumber="${manufacturerPartNumber}"
+${manufacturerPartNumberProp}\
       footprint={${footprintTsx}}
       ${
         objUrl || stepUrl

--- a/lib/websafe/convert-to-typescript-component/index.tsx
+++ b/lib/websafe/convert-to-typescript-component/index.tsx
@@ -55,8 +55,11 @@ export const convertBetterEasyToTsx = async ({
     cadComponent.position.x = 0
     cadComponent.position.y = 0
   }
-  const rawPn = betterEasy.dataStr.head.c_para["Manufacturer Part"]
-  const pn = rawPn ? normalizeManufacturerPartNumber(rawPn) : "unknown"
+  const manufacturerPartNumber =
+    betterEasy.dataStr.head.c_para["Manufacturer Part"]
+  const componentName = normalizeManufacturerPartNumber(
+    manufacturerPartNumber || betterEasy.lcsc.number,
+  )
   const sourcePorts = su(circuitJson).source_port.list()
 
   const pinLabels: Record<string, string[]> = {}
@@ -97,8 +100,8 @@ export const convertBetterEasyToTsx = async ({
       : undefined
 
   return generateTypescriptComponent({
-    componentName: pn,
-    manufacturerPartNumber: rawPn || "unknown",
+    componentName,
+    manufacturerPartNumber,
     pinLabels,
 
     objUrl: modelObjUrl,

--- a/lib/websafe/convert-to-typescript-component/index.tsx
+++ b/lib/websafe/convert-to-typescript-component/index.tsx
@@ -57,9 +57,12 @@ export const convertBetterEasyToTsx = async ({
   }
   const manufacturerPartNumber =
     betterEasy.dataStr.head.c_para["Manufacturer Part"]
-  const componentName = normalizeManufacturerPartNumber(
-    manufacturerPartNumber || betterEasy.lcsc.number,
-  )
+  if (!manufacturerPartNumber) {
+    throw new Error(
+      `Missing manufacturer part number for ${betterEasy.lcsc.number}`,
+    )
+  }
+  const componentName = normalizeManufacturerPartNumber(manufacturerPartNumber)
   const sourcePorts = su(circuitJson).source_port.list()
 
   const pinLabels: Record<string, string[]> = {}

--- a/lib/websafe/convert-to-typescript-component/index.tsx
+++ b/lib/websafe/convert-to-typescript-component/index.tsx
@@ -98,7 +98,7 @@ export const convertBetterEasyToTsx = async ({
 
   return generateTypescriptComponent({
     componentName: pn,
-    manufacturerPartNumber: pn,
+    manufacturerPartNumber: rawPn || "unknown",
     pinLabels,
 
     objUrl: modelObjUrl,

--- a/tests/convert-to-ts/C105419-to-ts.test.ts
+++ b/tests/convert-to-ts/C105419-to-ts.test.ts
@@ -46,7 +46,7 @@ it("should convert C105419 into typescript file", async () => {
         "C105419"
       ]
     }}
-          manufacturerPartNumber="TF_02A"
+          manufacturerPartNumber="TF-02A"
           footprint={<footprint>
             <smtpad portHints={["pin1"]} pcbX="-3.00000035mm" pcbY="-1.725676mm" width="1.5999968mm" height="0.6999986mm" shape="rect" />
     <smtpad portHints={["pin2"]} pcbX="-2.65506835mm" pcbY="-0.625094mm" width="1.5999968mm" height="0.6999986mm" shape="rect" />

--- a/tests/convert-to-ts/C131337-to-ts.test.ts
+++ b/tests/convert-to-ts/C131337-to-ts.test.ts
@@ -38,7 +38,7 @@ it("should convert C131337 into typescript file", async () => {
         "C131337"
       ]
     }}
-          manufacturerPartNumber="B2B_PH_K_S_LF__SN_"
+          manufacturerPartNumber="B2B-PH-K-S(LF)(SN)"
           footprint={<footprint>
             <platedhole  portHints={["pin2"]} pcbX="-0.999998mm" pcbY="0mm" outerDiameter="1.5999968mm" holeDiameter="0.9000236mm" shape="circle" />
     <platedhole  portHints={["pin1"]} pcbX="0.999998mm" pcbY="0mm" outerDiameter="1.5999968mm" holeDiameter="0.9000236mm" shape="circle" />

--- a/tests/convert-to-ts/C136720-to-ts.test.ts
+++ b/tests/convert-to-ts/C136720-to-ts.test.ts
@@ -42,7 +42,7 @@ it("should convert C136720 slide switch into a switch component with pin labels"
         "C136720"
       ]
     }}
-          manufacturerPartNumber="SK_12E12_G5"
+          manufacturerPartNumber="SK-12E12-G5"
           footprint={<footprint>
             <platedhole  portHints={["pin2"]} pcbX="0mm" pcbY="0.127mm" outerDiameter="1.524mm" holeDiameter="0.999998mm" shape="circle" />
     <platedhole  portHints={["pin3"]} pcbX="0mm" pcbY="-2.921mm" outerDiameter="1.524mm" holeDiameter="0.999998mm" shape="circle" />

--- a/tests/convert-to-ts/C14877-to-ts.test.ts
+++ b/tests/convert-to-ts/C14877-to-ts.test.ts
@@ -66,7 +66,7 @@ it("should convert C14877 into typescript file", async () => {
         "C14877"
       ]
     }}
-          manufacturerPartNumber="ATMEGA328P_AU"
+          manufacturerPartNumber="ATMEGA328P-AU"
           footprint={<footprint>
             <smtpad portHints={["pin32"]} pcbX="-4.3815mm" pcbY="-2.7999944mm" width="1.6500094mm" height="0.4500118mm" radius="0.2250059mm" shape="pill" />
     <smtpad portHints={["pin31"]} pcbX="-4.3815mm" pcbY="-1.999996mm" width="1.6500094mm" height="0.4500118mm" radius="0.2250059mm" shape="pill" />

--- a/tests/convert-to-ts/C157929-to-ts.test.ts
+++ b/tests/convert-to-ts/C157929-to-ts.test.ts
@@ -39,7 +39,7 @@ it("should convert C157929 into typescript file", async () => {
         "C157929"
       ]
     }}
-          manufacturerPartNumber="S3B_PH_K_S_LF__SN_"
+          manufacturerPartNumber="S3B-PH-K-S(LF)(SN)"
           footprint={<footprint>
             <platedhole  portHints={["pin3"]} pcbX="1.999996mm" pcbY="0mm" outerDiameter="1.499997mm" holeDiameter="0.9000236mm" shape="circle" />
     <platedhole  portHints={["pin2"]} pcbX="-0mm" pcbY="0mm" outerDiameter="1.499997mm" holeDiameter="0.9000236mm" shape="circle" />

--- a/tests/convert-to-ts/C157947-to-ts.test.ts
+++ b/tests/convert-to-ts/C157947-to-ts.test.ts
@@ -44,7 +44,7 @@ it("should convert C157947 into typescript file", async () => {
         "C157947"
       ]
     }}
-          manufacturerPartNumber="S10B_PH_K_S_LF__SN_"
+          manufacturerPartNumber="S10B-PH-K-S(LF)(SN)"
           footprint={<footprint>
             <platedhole  portHints={["pin10"]} pcbX="8.999982mm" pcbY="0mm" outerDiameter="1.499997mm" holeDiameter="0.999998mm" shape="circle" />
     <platedhole  portHints={["pin9"]} pcbX="6.999986mm" pcbY="0mm" outerDiameter="1.499997mm" holeDiameter="0.999998mm" shape="circle" />

--- a/tests/convert-to-ts/C158012-to-ts.test.ts
+++ b/tests/convert-to-ts/C158012-to-ts.test.ts
@@ -38,7 +38,7 @@ it("should convert C158012 into typescript file", async () => {
         "C158012"
       ]
     }}
-          manufacturerPartNumber="B2B_XH_A_LF__SN_"
+          manufacturerPartNumber="B2B-XH-A(LF)(SN)"
           footprint={<footprint>
             <platedhole  portHints={["pin1"]} pcbX="1.2499975mm" pcbY="0mm" outerDiameter="1.6999966mm" holeDiameter="0.999998mm" shape="circle" />
     <platedhole  portHints={["pin2"]} pcbX="-1.2499975mm" pcbY="0mm" outerDiameter="1.6999966mm" holeDiameter="0.999998mm" shape="circle" />

--- a/tests/convert-to-ts/C160354-to-ts.test.ts
+++ b/tests/convert-to-ts/C160354-to-ts.test.ts
@@ -40,7 +40,7 @@ it("should convert C160354 into typescript file", async () => {
         "C160354"
       ]
     }}
-          manufacturerPartNumber="B4B_PH_SM4_TB_LF__SN_"
+          manufacturerPartNumber="B4B-PH-SM4-TB(LF)(SN)"
           footprint={<footprint>
             <smtpad portHints={["pin1"]} pcbX="2.996946mm" pcbY="0.5079873mm" width="0.999998mm" height="5.999988mm" shape="rect" />
     <smtpad portHints={["pin2"]} pcbX="0.99695mm" pcbY="0.5079873mm" width="0.999998mm" height="5.999988mm" shape="rect" />

--- a/tests/convert-to-ts/C165948-to-ts.test.ts
+++ b/tests/convert-to-ts/C165948-to-ts.test.ts
@@ -50,7 +50,7 @@ it("should convert C165948 into typescript file", async () => {
         "C165948"
       ]
     }}
-          manufacturerPartNumber="TYPE_C_31_M_12"
+          manufacturerPartNumber="TYPE-C-31-M-12"
           footprint={<footprint>
             <hole pcbX="-2.899918mm" pcbY="0.9055672mm" diameter="0.7500112mm" />
     <hole pcbX="2.899918mm" pcbY="0.9055672mm" diameter="0.7500112mm" />

--- a/tests/convert-to-ts/C18185602-to-ts.test.ts
+++ b/tests/convert-to-ts/C18185602-to-ts.test.ts
@@ -58,7 +58,7 @@ it("should convert C18185602 into typescript file", async () => {
         "C18185602"
       ]
     }}
-          manufacturerPartNumber="PJ_320A_4P_DIP"
+          manufacturerPartNumber="PJ-320A-4P DIP"
           footprint={<footprint>
             <hole pcbX="2.4249824mm" pcbY="0mm" diameter="1.1999976mm" />
     <hole pcbX="-4.5750036mm" pcbY="0mm" diameter="1.1999976mm" />

--- a/tests/convert-to-ts/C19076967-to-ts.test.ts
+++ b/tests/convert-to-ts/C19076967-to-ts.test.ts
@@ -45,7 +45,7 @@ it("should convert C19076967 into typescript file", async () => {
         "C19076967"
       ]
     }}
-          manufacturerPartNumber="MFR01_A1F03L1S_B"
+          manufacturerPartNumber="MFR01-A1F03L1S-B"
           footprint={<footprint>
             <platedhole  portHints={["pin5"]} pcbX="-0.016891mm" pcbY="-12.100052mm" holeWidth="1.5000224mm" holeHeight="3.90005824mm" outerWidth="2.1999956mm" outerHeight="5.1999896mm" rectPad={true} pcbRotation="270deg" shape="pill" />
     <platedhole  portHints={["pin11"]} pcbX="0.016891mm" pcbY="12.100052mm" holeWidth="1.5000224mm" holeHeight="3.90005824mm" outerWidth="2.1999956mm" outerHeight="5.1999896mm" rectPad={true} pcbRotation="270deg" shape="pill" />

--- a/tests/convert-to-ts/C19795120-to-ts.test.ts
+++ b/tests/convert-to-ts/C19795120-to-ts.test.ts
@@ -40,7 +40,7 @@ it("should convert C19795120 into typescript file", async () => {
         "C19795120"
       ]
     }}
-          manufacturerPartNumber="A_470533000"
+          manufacturerPartNumber="470533000"
           footprint={<footprint>
             <hole pcbX="-1.27mm" pcbY="-1.1975084mm" diameter="1.2499848mm" />
     <platedhole  portHints={["pin1"]} pcbX="3.81mm" pcbY="0.9625076mm" outerDiameter="1.7199864mm" holeDiameter="1.0200132mm" shape="circle" />

--- a/tests/convert-to-ts/C22446580-to-ts.test.ts
+++ b/tests/convert-to-ts/C22446580-to-ts.test.ts
@@ -51,7 +51,7 @@ it("should convert C22446580 into typescript file", async () => {
         "C22446580"
       ]
     }}
-          manufacturerPartNumber="A_74HC4051LQ_TR"
+          manufacturerPartNumber="74HC4051LQ/TR"
           footprint={<footprint>
             <smtpad portHints={["pin1"]} pcbX="-1.499997mm" pcbY="0.750062mm" width="0.7999984mm" height="0.2800096mm" radius="0.1400048mm" shape="pill" />
     <smtpad portHints={["pin2"]} pcbX="-1.499997mm" pcbY="0.249936mm" width="0.7999984mm" height="0.2800096mm" radius="0.1400048mm" shape="pill" />

--- a/tests/convert-to-ts/C22446580.test.ts
+++ b/tests/convert-to-ts/C22446580.test.ts
@@ -48,7 +48,7 @@ it("should convert C22446580 into typescript file", async () => {
         "C22446580"
       ]
     }}
-          manufacturerPartNumber="A_74HC4051LQ_TR"
+          manufacturerPartNumber="74HC4051LQ/TR"
           footprint={<footprint>
             <smtpad portHints={["pin1"]} pcbX="-1.499997mm" pcbY="0.750062mm" width="0.7999984mm" height="0.2800096mm" radius="0.1400048mm" shape="pill" />
     <smtpad portHints={["pin2"]} pcbX="-1.499997mm" pcbY="0.249936mm" width="0.7999984mm" height="0.2800096mm" radius="0.1400048mm" shape="pill" />

--- a/tests/convert-to-ts/C23689428-to-ts.test.ts
+++ b/tests/convert-to-ts/C23689428-to-ts.test.ts
@@ -43,7 +43,7 @@ it("should convert C23689428 into typescript file", async () => {
         "C23689428"
       ]
     }}
-          manufacturerPartNumber="DIN_504"
+          manufacturerPartNumber="DIN-504"
           footprint={<footprint>
             <platedhole  portHints={["pin1"]} pcbX="3.850005mm" pcbY="-7.499985mm" outerDiameter="1.999996mm" holeDiameter="1.3000228mm" shape="circle" />
     <platedhole  portHints={["pin2"]} pcbX="3.850005mm" pcbY="0.000127mm" outerDiameter="1.999996mm" holeDiameter="1.3000228mm" shape="circle" />

--- a/tests/convert-to-ts/C265111-to-ts.test.ts
+++ b/tests/convert-to-ts/C265111-to-ts.test.ts
@@ -44,7 +44,7 @@ it("should convert C265111 into typescript file", async () => {
         "C265111"
       ]
     }}
-          manufacturerPartNumber="SM08B_GHS_TB_LF__SN_"
+          manufacturerPartNumber="SM08B-GHS-TB(LF)(SN)"
           footprint={<footprint>
             <smtpad portHints={["pin10"]} pcbX="6.225032mm" pcbY="-1.3499465mm" width="1.2100052mm" height="2.6999946mm" shape="rect" />
     <smtpad portHints={["pin9"]} pcbX="-6.225032mm" pcbY="-1.3499465mm" width="1.2100052mm" height="2.6999946mm" shape="rect" />

--- a/tests/convert-to-ts/C281113-to-ts.test.ts
+++ b/tests/convert-to-ts/C281113-to-ts.test.ts
@@ -51,7 +51,7 @@ it("should convert C281113 into typescript file", async () => {
         "C281113"
       ]
     }}
-          manufacturerPartNumber="MGFL2012F100MT_LF"
+          manufacturerPartNumber="MGFL2012F100MT-LF"
           footprint={<footprint>
             <smtpad portHints={["pin1"]} pcbX="-0.966216mm" pcbY="0mm" width="1.1325352mm" height="1.3770102mm" shape="rect" />
     <smtpad portHints={["pin2"]} pcbX="0.966216mm" pcbY="0mm" width="1.1325352mm" height="1.3770102mm" shape="rect" />

--- a/tests/convert-to-ts/C2828420-to-ts.test.ts
+++ b/tests/convert-to-ts/C2828420-to-ts.test.ts
@@ -62,7 +62,7 @@ it("should convert C2828420 diode with metadata-derived pin labels", async () =>
         "C2828420"
       ]
     }}
-          manufacturerPartNumber="A_1N5819W"
+          manufacturerPartNumber="1N5819W"
           footprint={<footprint>
             <smtpad portHints={["pin2","anode","pos"]} pcbX="1.700022mm" pcbY="0mm" width="1.1999976mm" height="0.9500108mm" shape="rect" />
     <smtpad portHints={["pin1","cathode","neg"]} pcbX="-1.700022mm" pcbY="0mm" width="1.1999976mm" height="0.9500108mm" shape="rect" />

--- a/tests/convert-to-ts/C2838502-to-ts.test.ts
+++ b/tests/convert-to-ts/C2838502-to-ts.test.ts
@@ -97,7 +97,7 @@ it("should convert C2838502 into typescript file", async () => {
         "C2838502"
       ]
     }}
-          manufacturerPartNumber="ESP32_C3_MINI_1_N4"
+          manufacturerPartNumber="ESP32-C3-MINI-1-N4"
           footprint={<footprint>
             <smtpad portHints={["pin1"]} pcbX="-5.899912mm" pcbY="3.999992mm" width="0.7999984mm" height="0.3999992mm" shape="rect" />
     <smtpad portHints={["pin2"]} pcbX="-5.899912mm" pcbY="3.199892mm" width="0.7999984mm" height="0.3999992mm" shape="rect" />

--- a/tests/convert-to-ts/C2848306-to-ts.test.ts
+++ b/tests/convert-to-ts/C2848306-to-ts.test.ts
@@ -39,7 +39,7 @@ it("should convert C2848306 into typescript file", async () => {
         "C2848306"
       ]
     }}
-          manufacturerPartNumber="SHT40_AD1B_R3"
+          manufacturerPartNumber="SHT40-AD1B-R3"
           footprint={<footprint>
             <smtpad portHints={["pin1"]} pcbX="-0.677418mm" pcbY="0.40005mm" width="0.5050028mm" height="0.419989mm" shape="rect" />
     <smtpad portHints={["pin2"]} pcbX="-0.677418mm" pcbY="-0.40005mm" width="0.5050028mm" height="0.419989mm" shape="rect" />

--- a/tests/convert-to-ts/C2913206-to-ts.test.ts
+++ b/tests/convert-to-ts/C2913206-to-ts.test.ts
@@ -107,7 +107,7 @@ it("should convert C2913206 into typescript file", async () => {
         "C2913206"
       ]
     }}
-          manufacturerPartNumber="ESP32_S3_MINI_1_N8"
+          manufacturerPartNumber="ESP32-S3-MINI-1-N8"
           footprint={<footprint>
             <smtpad portHints={["pin1"]} pcbX="-6.975094mm" pcbY="5.950077mm" width="0.7999984mm" height="0.3999992mm" shape="rect" />
     <smtpad portHints={["pin2"]} pcbX="-6.975094mm" pcbY="5.100193mm" width="0.7999984mm" height="0.3999992mm" shape="rect" />

--- a/tests/convert-to-ts/C2961147-to-ts.test.ts
+++ b/tests/convert-to-ts/C2961147-to-ts.test.ts
@@ -73,7 +73,7 @@ it("should convert C2961147 into typescript file", async () => {
         "C2961147"
       ]
     }}
-          manufacturerPartNumber="PJ_002AH"
+          manufacturerPartNumber="PJ-002AH"
           footprint={<footprint>
             <platedhole  portHints={["pin3"]} pcbX="-0mm" pcbY="2.350008mm" holeWidth="0.999998mm" holeHeight="3.1999936mm" outerWidth="1.7999964mm" outerHeight="3.999992mm" pcbRotation="90deg" shape="pill" />
     <platedhole  portHints={["pin2"]} pcbX="2.999994mm" pcbY="-2.350008mm" holeWidth="0.999998mm" holeHeight="3.1999936mm" outerWidth="1.7999964mm" outerHeight="3.999992mm" shape="pill" />

--- a/tests/convert-to-ts/C2979182-to-ts.test.ts
+++ b/tests/convert-to-ts/C2979182-to-ts.test.ts
@@ -36,7 +36,7 @@ it("should convert C2979182 / MY-18650-02 into typescript file", async () => {
         "C2979182"
       ]
     }}
-          manufacturerPartNumber="MY_18650_02"
+          manufacturerPartNumber="MY-18650-02"
           footprint={<footprint>
             <smtpad portHints={["pin2"]} pcbX="8.499983mm" pcbY="0mm" width="4.99999mm" height="5.499989mm" shape="rect" />
     <smtpad portHints={["pin1"]} pcbX="-8.499983mm" pcbY="0mm" width="4.99999mm" height="3.499993mm" shape="rect" />

--- a/tests/convert-to-ts/C2998002-to-ts.test.ts
+++ b/tests/convert-to-ts/C2998002-to-ts.test.ts
@@ -67,7 +67,7 @@ it("should convert C2998002 into typescript file", async () => {
         "C2998002"
       ]
     }}
-          manufacturerPartNumber="BCM62B_215"
+          manufacturerPartNumber="BCM62B,215"
           footprint={<footprint>
             <smtpad portHints={["pin1"]} pcbX="1.099947mm" pcbY="-0.72501125mm" width="0.6999986mm" height="1.0999978mm" shape="rect" />
     <smtpad portHints={["pin2"]} pcbX="1.099947mm" pcbY="0.97501075mm" width="0.6999986mm" height="0.5999988mm" shape="rect" />

--- a/tests/convert-to-ts/C309274-to-ts.test.ts
+++ b/tests/convert-to-ts/C309274-to-ts.test.ts
@@ -68,7 +68,7 @@ it("should convert C309274 into typescript file", async () => {
         "C309274"
       ]
     }}
-          manufacturerPartNumber="PJ_609"
+          manufacturerPartNumber="PJ-609"
           footprint={<footprint>
             <platedhole  portHints={["pin2"]} pcbX="-6.299962mm" pcbY="-8.10006mm" holeWidth="0.7999984mm" holeHeight="2.3999952mm" outerWidth="1.5999968mm" outerHeight="3.1999936mm" pcbRotation="270deg" shape="pill" />
     <platedhole  portHints={["pin3"]} pcbX="-6.299962mm" pcbY="8.10006mm" holeWidth="0.7999984mm" holeHeight="2.3999952mm" outerWidth="1.5999968mm" outerHeight="3.1999936mm" pcbRotation="270deg" shape="pill" />

--- a/tests/convert-to-ts/C3178291-to-ts.test.ts
+++ b/tests/convert-to-ts/C3178291-to-ts.test.ts
@@ -46,7 +46,7 @@ it("should convert C3178291 into typescript file", async () => {
         "C3178291"
       ]
     }}
-          manufacturerPartNumber="VL53L4CDV0DH_1"
+          manufacturerPartNumber="VL53L4CDV0DH/1"
           footprint={<footprint>
             <smtpad portHints={["pin10"]} pcbX="0.7682738mm" pcbY="0.7999984mm" width="0.508mm" height="0.508mm" shape="rect" />
     <smtpad portHints={["pin11"]} pcbX="1.5683738mm" pcbY="0.7999984mm" width="0.508mm" height="0.508mm" shape="rect" />

--- a/tests/convert-to-ts/C393941-to-ts.test.ts
+++ b/tests/convert-to-ts/C393941-to-ts.test.ts
@@ -49,7 +49,7 @@ it("should convert C393941 into typescript file", async () => {
         "C393941"
       ]
     }}
-          manufacturerPartNumber="TF_PUSH"
+          manufacturerPartNumber="TF PUSH"
           footprint={<footprint>
             <hole pcbX="-4.949952mm" pcbY="-5.5500143mm" diameter="1.1999976mm" />
     <hole pcbX="3.050032mm" pcbY="-5.5500143mm" diameter="1.1999976mm" />

--- a/tests/convert-to-ts/C410353-to-ts.test.ts
+++ b/tests/convert-to-ts/C410353-to-ts.test.ts
@@ -47,7 +47,7 @@ it("should convert C410353 into typescript file", async () => {
         "C410353"
       ]
     }}
-          manufacturerPartNumber="SD_111"
+          manufacturerPartNumber="SD-111"
           footprint={<footprint>
             <hole pcbX="-12.200001mm" pcbY="-12.1249567mm" diameter="1.700022mm" />
     <hole pcbX="12.000103mm" pcbY="-12.1249567mm" diameter="1.700022mm" />

--- a/tests/convert-to-ts/C51950748-to-ts.test.ts
+++ b/tests/convert-to-ts/C51950748-to-ts.test.ts
@@ -78,7 +78,7 @@ it("should convert C51950748 into typescript file", async () => {
         "C51950748"
       ]
     }}
-          manufacturerPartNumber="ESP32_C5_WROOM_1U_N8R8"
+          manufacturerPartNumber="ESP32-C5-WROOM-1U-N8R8"
           footprint={<footprint>
             <smtpad portHints={["pin1"]} pcbX="-8.877046mm" pcbY="7.3850373mm" width="1.499997mm" height="0.8999982mm" shape="rect" />
     <smtpad portHints={["pin2"]} pcbX="-8.876792mm" pcbY="6.1150373mm" width="1.499997mm" height="0.8999982mm" shape="rect" />

--- a/tests/convert-to-ts/C561765-to-ts.test.ts
+++ b/tests/convert-to-ts/C561765-to-ts.test.ts
@@ -38,7 +38,7 @@ it("should convert C561765 into typescript file", async () => {
         "C561765"
       ]
     }}
-          manufacturerPartNumber="A_1053131104"
+          manufacturerPartNumber="1053131104"
           footprint={<footprint>
             <hole pcbX="-3.749929mm" pcbY="-3.6400359mm" diameter="1.5999968mm" />
     <hole pcbX="3.749929mm" pcbY="-3.6400359mm" diameter="1.5999968mm" />

--- a/tests/convert-to-ts/C57759-to-led.test.ts
+++ b/tests/convert-to-ts/C57759-to-led.test.ts
@@ -33,7 +33,7 @@ it("should convert led category components to led elements", async () => {
         "C57759"
       ]
     }}
-          manufacturerPartNumber="A_1N4148WS"
+          manufacturerPartNumber="1N4148WS"
           footprint={<footprint>
             <smtpad portHints={["pin1","cathode","neg"]} pcbX="-1.172591mm" pcbY="0mm" width="0.999998mm" height="0.7500112mm" shape="rect" />
     <smtpad portHints={["pin2","anode","pos"]} pcbX="1.172591mm" pcbY="0mm" width="0.999998mm" height="0.7500112mm" shape="rect" />

--- a/tests/convert-to-ts/C57759-to-ts.test.ts
+++ b/tests/convert-to-ts/C57759-to-ts.test.ts
@@ -33,7 +33,7 @@ it("should convert diode category components to diode elements", async () => {
         "C57759"
       ]
     }}
-          manufacturerPartNumber="A_1N4148WS"
+          manufacturerPartNumber="1N4148WS"
           footprint={<footprint>
             <smtpad portHints={["pin1","cathode","neg"]} pcbX="-1.172591mm" pcbY="0mm" width="0.999998mm" height="0.7500112mm" shape="rect" />
     <smtpad portHints={["pin2","anode","pos"]} pcbX="1.172591mm" pcbY="0mm" width="0.999998mm" height="0.7500112mm" shape="rect" />

--- a/tests/convert-to-ts/C6186-to-ts.test.ts
+++ b/tests/convert-to-ts/C6186-to-ts.test.ts
@@ -38,7 +38,7 @@ it("should convert C6186 into typescript file", async () => {
         "C6186"
       ]
     }}
-          manufacturerPartNumber="AMS1117_3_3"
+          manufacturerPartNumber="AMS1117-3.3"
           footprint={<footprint>
             <smtpad portHints={["pin1"]} pcbX="2.92995985mm" pcbY="-2.29997mm" width="2.499995mm" height="1.0999978mm" shape="rect" />
     <smtpad portHints={["pin2"]} pcbX="2.92995985mm" pcbY="0mm" width="2.499995mm" height="1.0999978mm" shape="rect" />

--- a/tests/convert-to-ts/C75749-to-ts.test.ts
+++ b/tests/convert-to-ts/C75749-to-ts.test.ts
@@ -95,7 +95,7 @@ it("should convert C75749 into typescript file", async () => {
         "C75749"
       ]
     }}
-          manufacturerPartNumber="DS1037_09FNAKT74_0CC"
+          manufacturerPartNumber="DS1037-09FNAKT74-0CC"
           footprint={<footprint>
             <platedhole  portHints={["pin3"]} pcbX="-1.41986mm" pcbY="-0.000127mm" outerDiameter="1.5748mm" holeDiameter="0.999998mm" shape="circle" />
     <platedhole  portHints={["pin11"]} pcbX="0mm" pcbY="-12.499975mm" outerDiameter="4.99999mm" holeDiameter="3.2500316mm" shape="circle" />

--- a/tests/convert-to-ts/C8465-to-ts.test.ts
+++ b/tests/convert-to-ts/C8465-to-ts.test.ts
@@ -38,7 +38,7 @@ it("should convert C8465 into typescript file", async () => {
         "C8465"
       ]
     }}
-          manufacturerPartNumber="WJ500V_5_08_2P"
+          manufacturerPartNumber="WJ500V-5.08-2P"
           footprint={<footprint>
             <platedhole  portHints={["pin2"]} pcbX="2.54mm" pcbY="0mm" outerDiameter="1.999996mm" holeDiameter="1.3000228mm" shape="circle" />
     <platedhole  portHints={["pin1"]} pcbX="-2.54mm" pcbY="0mm" outerDiameter="1.999996mm" holeDiameter="1.3000228mm" shape="circle" />

--- a/tests/convert-to-ts/C8598-to-ts.test.ts
+++ b/tests/convert-to-ts/C8598-to-ts.test.ts
@@ -62,7 +62,7 @@ it("should normalize decorated C8598 diode polarity labels", async () => {
         "C8598"
       ]
     }}
-          manufacturerPartNumber="B5819W_SL"
+          manufacturerPartNumber="B5819W SL"
           footprint={<footprint>
             <smtpad portHints={["pin2","anode","pos"]} pcbX="1.700022mm" pcbY="0mm" width="1.1999976mm" height="0.9500108mm" shape="rect" />
     <smtpad portHints={["pin1","cathode","neg"]} pcbX="-1.700022mm" pcbY="0mm" width="1.1999976mm" height="0.9500108mm" shape="rect" />

--- a/tests/convert-to-ts/C88224-to-ts.test.ts
+++ b/tests/convert-to-ts/C88224-to-ts.test.ts
@@ -58,7 +58,7 @@ it("should convert C88224 into typescript file", async () => {
         "C88224"
       ]
     }}
-          manufacturerPartNumber="TB6612FNG_O_C_8_EL"
+          manufacturerPartNumber="TB6612FNG(O,C,8,EL"
           footprint={<footprint>
             <smtpad portHints={["pin1"]} pcbX="-3.57505mm" pcbY="-3.490976mm" width="0.3640074mm" height="2.0820126mm" radius="0.1820037mm" shape="pill" />
     <smtpad portHints={["pin2"]} pcbX="-2.925064mm" pcbY="-3.490976mm" width="0.3640074mm" height="2.0820126mm" radius="0.1820037mm" shape="pill" />

--- a/tests/convert-to-ts/C9972-to-ts.test.ts
+++ b/tests/convert-to-ts/C9972-to-ts.test.ts
@@ -11,7 +11,7 @@ it("preserves the exact C9972 manufacturer part number", async () => {
   expect(result).toContain('manufacturerPartNumber="XC6206P302MR-G"')
 })
 
-it("omits missing manufacturer part number metadata", async () => {
+it("reports missing manufacturer part number metadata", async () => {
   const rawEasyWithoutManufacturerPartNumber = structuredClone(chipRawEasy)
   rawEasyWithoutManufacturerPartNumber.dataStr.head.c_para[
     "Manufacturer Part"
@@ -19,8 +19,7 @@ it("omits missing manufacturer part number metadata", async () => {
   const betterEasy = EasyEdaJsonSchema.parse(
     rawEasyWithoutManufacturerPartNumber,
   )
-  const result = await convertBetterEasyToTsx({ betterEasy })
-
-  expect(result).toContain("export const C9972")
-  expect(result).not.toContain("manufacturerPartNumber=")
+  await expect(convertBetterEasyToTsx({ betterEasy })).rejects.toThrow(
+    "Missing manufacturer part number for C9972",
+  )
 })

--- a/tests/convert-to-ts/C9972-to-ts.test.ts
+++ b/tests/convert-to-ts/C9972-to-ts.test.ts
@@ -10,3 +10,17 @@ it("preserves the exact C9972 manufacturer part number", async () => {
   expect(result).toContain("export const XC6206P302MR_G")
   expect(result).toContain('manufacturerPartNumber="XC6206P302MR-G"')
 })
+
+it("omits missing manufacturer part number metadata", async () => {
+  const rawEasyWithoutManufacturerPartNumber = structuredClone(chipRawEasy)
+  rawEasyWithoutManufacturerPartNumber.dataStr.head.c_para[
+    "Manufacturer Part"
+  ] = null
+  const betterEasy = EasyEdaJsonSchema.parse(
+    rawEasyWithoutManufacturerPartNumber,
+  )
+  const result = await convertBetterEasyToTsx({ betterEasy })
+
+  expect(result).toContain("export const C9972")
+  expect(result).not.toContain("manufacturerPartNumber=")
+})

--- a/tests/convert-to-ts/C9972-to-ts.test.ts
+++ b/tests/convert-to-ts/C9972-to-ts.test.ts
@@ -3,10 +3,10 @@ import { EasyEdaJsonSchema } from "lib/schemas/easy-eda-json-schema"
 import { convertBetterEasyToTsx } from "lib/websafe/convert-to-typescript-component"
 import chipRawEasy from "../assets/C9972.raweasy.json"
 
-it("reproduces C9972 manufacturer part number normalization", async () => {
+it("preserves the exact C9972 manufacturer part number", async () => {
   const betterEasy = EasyEdaJsonSchema.parse(chipRawEasy)
   const result = await convertBetterEasyToTsx({ betterEasy })
 
   expect(result).toContain("export const XC6206P302MR_G")
-  expect(result).toContain('manufacturerPartNumber="XC6206P302MR_G"')
+  expect(result).toContain('manufacturerPartNumber="XC6206P302MR-G"')
 })


### PR DESCRIPTION
## Summary

- stack base: #432
- preserve the exact EasyEDA manufacturer part number in generated component metadata
- report a clear conversion error when EasyEDA does not provide a manufacturer part number instead of emitting fabricated `"unknown"` metadata
- update existing inline expectations to match their exact supplier fixtures

## Root cause

`convertBetterEasyToTsx` normalized the manufacturer part number for both the TypeScript identifier and component metadata. This altered real manufacturer metadata such as `XC6206P302MR-G`.

The first fix also used unclear `rawPn` / `pn` names and assigned `"unknown"` as a real manufacturer part number when the source field was absent. That obscured the value's meaning and produced false BOM metadata.

The converter now checks the nullable EasyEDA field at its input boundary. When present, it keeps `manufacturerPartNumber` unchanged end-to-end and derives `componentName` separately. When absent, it reports `Missing manufacturer part number for <LCSC number>`. The generator's existing required-string contract remains unchanged.

## Validation

- C9972 exact-MPN regression passes
- missing-MPN regression passes and reports `Missing manufacturer part number for C9972`
- full network-enabled suite: 137 passed, 0 failed, 56 snapshots
- `bun run format:check`
- `bun run build`
