### PR TITLE
Generate four-pin crystals from EasyEDA metadata

### DIFF
--- a/lib/websafe/convert-to-typescript-component/generate-typescript-component.ts
+++ b/lib/websafe/convert-to-typescript-component/generate-typescript-component.ts
@@ -9,6 +9,7 @@ export type GeneratedComponentType =
   | "led"
   | "pushbutton"
   | "switch"
+  | "crystal"
 
 interface Params {
   pinLabels: ChipProps["pinLabels"]
@@ -19,6 +20,8 @@ interface Params {
   supplierPartNumbers: SupplierPartNumbers
   manufacturerPartNumber: string
   componentType?: GeneratedComponentType
+  crystalFrequency?: string
+  crystalPinVariant?: "two_pin" | "four_pin"
   symbolTsx?: string
 }
 
@@ -31,6 +34,8 @@ export const generateTypescriptComponent = ({
   supplierPartNumbers,
   manufacturerPartNumber,
   componentType = "chip",
+  crystalFrequency,
+  crystalPinVariant,
   symbolTsx,
 }: Params) => {
   // Ensure pinLabels is defined
@@ -203,6 +208,41 @@ export const ${componentName} = (props: SwitchProps) => {
       name={name}
       pinLabels={pinLabels}
 ${symbolProp}\
+      supplierPartNumbers={${JSON.stringify(supplierPartNumbers, null, "  ")}}
+      manufacturerPartNumber="${manufacturerPartNumber}"
+      footprint={${footprintTsx}}
+      ${
+        objUrl || stepUrl
+          ? `cadModel={{
+${cadModelLines}
+      }}`
+          : ""
+      }
+      {...restProps}
+    />
+  )
+}
+`.trim()
+  }
+
+  if (componentType === "crystal") {
+    if (!crystalFrequency || !crystalPinVariant) {
+      throw new Error("Crystal frequency and pin variant are required")
+    }
+
+    return `
+import type { CrystalProps } from "@tscircuit/props"
+
+type ImportedCrystalProps = Omit<CrystalProps, "frequency" | "pinVariant">
+
+export const ${componentName} = (props: ImportedCrystalProps) => {
+  const { name = "X1", ...restProps } = props
+
+  return (
+    <crystal
+      name={name}
+      frequency=${JSON.stringify(crystalFrequency)}
+      pinVariant=${JSON.stringify(crystalPinVariant)}
       supplierPartNumbers={${JSON.stringify(supplierPartNumbers, null, "  ")}}
       manufacturerPartNumber="${manufacturerPartNumber}"
       footprint={${footprintTsx}}

--- a/lib/websafe/convert-to-typescript-component/index.tsx
+++ b/lib/websafe/convert-to-typescript-component/index.tsx
@@ -8,6 +8,7 @@ import { normalizeManufacturerPartNumber } from "lib/utils/normalize-manufacture
 import { getEasyEdaCadModelPlacement } from "../get-easyeda-cad-model-placement"
 import { generateTypescriptComponent } from "./generate-typescript-component"
 import type { GeneratedComponentType } from "./generate-typescript-component"
+import { isCrystalComponent } from "./is-crystal-component"
 import { isDiodeCategoryComponent } from "./is-diode-category-component"
 import { isLedCategoryComponent } from "./is-led-category-component"
 import { isPushbuttonCategoryComponent } from "./is-pushbutton-category-component"
@@ -24,6 +25,7 @@ const getGeneratedComponentType = (
   if (isDiodeCategoryComponent(betterEasy)) return "diode"
   if (isPushbuttonCategoryComponent(betterEasy)) return "pushbutton"
   if (isSwitchCategoryComponent(betterEasy)) return "switch"
+  if (isCrystalComponent(betterEasy)) return "crystal"
   return "chip"
 }
 
@@ -91,6 +93,18 @@ export const convertBetterEasyToTsx = async ({
     jlcpcb: [betterEasy.lcsc.number],
   }
   const componentType = getGeneratedComponentType(betterEasy)
+  const crystalFrequency =
+    componentType === "crystal"
+      ? betterEasy.dataStr.head.c_para.Value?.trim()
+      : undefined
+  const crystalPinVariant =
+    componentType !== "crystal"
+      ? undefined
+      : sourcePorts.length === 4
+        ? "four_pin"
+        : sourcePorts.length === 2
+          ? "two_pin"
+          : undefined
   const symbolTsx =
     componentType === "chip" && hasNonBoxSchematicSymbol(betterEasy)
       ? generateSymbolTsx(betterEasy, circuitJson)
@@ -106,6 +120,8 @@ export const convertBetterEasyToTsx = async ({
     circuitJson,
     supplierPartNumbers,
     componentType,
+    crystalFrequency,
+    crystalPinVariant,
     symbolTsx,
   })
 }

--- a/lib/websafe/convert-to-typescript-component/is-crystal-component.ts
+++ b/lib/websafe/convert-to-typescript-component/is-crystal-component.ts
@@ -1,0 +1,16 @@
+import type { BetterEasyEdaJson } from "lib/schemas/easy-eda-json-schema"
+
+const frequencyPattern = /^\d+(?:\.\d+)?\s*(?:Hz|kHz|MHz|GHz)$/i
+
+export const isCrystalComponent = (betterEasy: BetterEasyEdaJson): boolean => {
+  const componentParameters = betterEasy.dataStr.head.c_para
+  const packageName = componentParameters.package
+  const value = componentParameters.Value
+
+  return (
+    componentParameters.pre === "X?" &&
+    packageName?.toUpperCase().startsWith("CRYSTAL-") === true &&
+    typeof value === "string" &&
+    frequencyPattern.test(value.trim())
+  )
+}

--- a/tests/convert-to-ts/C284163-to-ts.test.ts
+++ b/tests/convert-to-ts/C284163-to-ts.test.ts
@@ -3,11 +3,18 @@ import { EasyEdaJsonSchema } from "lib/schemas/easy-eda-json-schema"
 import { convertBetterEasyToTsx } from "lib/websafe/convert-to-typescript-component"
 import crystalRawEasy from "../assets/C284163.raweasy.json"
 
-it("reproduces C284163 as a generic chip", async () => {
+it("converts C284163 to a four-pin crystal", async () => {
   const betterEasy = EasyEdaJsonSchema.parse(crystalRawEasy)
   const result = await convertBetterEasyToTsx({ betterEasy })
 
-  expect(result).toContain('import type { ChipProps } from "@tscircuit/props"')
-  expect(result).toContain("<chip")
-  expect(result).not.toContain("<crystal")
+  expect(result).toContain(
+    'import type { CrystalProps } from "@tscircuit/props"',
+  )
+  expect(result).toContain(
+    'type ImportedCrystalProps = Omit<CrystalProps, "frequency" | "pinVariant">',
+  )
+  expect(result).toContain("<crystal")
+  expect(result).toContain('frequency="24MHz"')
+  expect(result).toContain('pinVariant="four_pin"')
+  expect(result).not.toContain("loadCapacitance=")
 })


### PR DESCRIPTION
## Summary

- classify conservative EasyEDA crystal metadata as a crystal instead of a generic chip
- emit the known frequency and two- or four-pin variant
- keep loadCapacitance required from the caller because C284163 does not provide that electrical value

## Stack

Depends on #434, which contains only the real C284163 fixture and failing-behavior reproduction. This PR changes that same focused test to demonstrate the corrected crystal output.

## Classification boundary

A part is classified as a crystal only when its EasyEDA reference is X?, its package starts with CRYSTAL-, and its value is a valid frequency. Unsupported pin counts fail explicitly.

## Validation

- bun test tests/convert-to-ts/C284163-to-ts.test.ts
- bun run format
- bun run build
- bun test: 137 passed, 0 failed