### PR TITLE
Generate inductors from EasyEDA metadata

### DIFF
--- a/lib/websafe/convert-to-typescript-component/generate-typescript-component.ts
+++ b/lib/websafe/convert-to-typescript-component/generate-typescript-component.ts
@@ -9,6 +9,7 @@ export type GeneratedComponentType =
   | "led"
   | "pushbutton"
   | "switch"
+  | "inductor"
 
 interface Params {
   pinLabels: ChipProps["pinLabels"]
@@ -19,6 +20,7 @@ interface Params {
   supplierPartNumbers: SupplierPartNumbers
   manufacturerPartNumber: string
   componentType?: GeneratedComponentType
+  inductance?: string
   symbolTsx?: string
 }
 
@@ -31,6 +33,7 @@ export const generateTypescriptComponent = ({
   supplierPartNumbers,
   manufacturerPartNumber,
   componentType = "chip",
+  inductance,
   symbolTsx,
 }: Params) => {
   // Ensure pinLabels is defined
@@ -214,6 +217,35 @@ ${cadModelLines}
           : ""
       }
       {...restProps}
+    />
+  )
+}
+`.trim()
+  }
+
+  if (componentType === "inductor") {
+    if (!inductance) {
+      throw new Error("Inductance is required for inductor components")
+    }
+
+    return `
+import type { InductorProps } from "@tscircuit/props"
+
+export const ${componentName} = (props: Omit<InductorProps, "inductance">) => {
+  return (
+    <inductor
+      inductance=${JSON.stringify(inductance)}
+      supplierPartNumbers={${JSON.stringify(supplierPartNumbers, null, "  ")}}
+      manufacturerPartNumber="${manufacturerPartNumber}"
+      footprint={${footprintTsx}}
+      ${
+        objUrl || stepUrl
+          ? `cadModel={{
+${cadModelLines}
+      }}`
+          : ""
+      }
+      {...props}
     />
   )
 }

--- a/lib/websafe/convert-to-typescript-component/index.tsx
+++ b/lib/websafe/convert-to-typescript-component/index.tsx
@@ -9,6 +9,7 @@ import { getEasyEdaCadModelPlacement } from "../get-easyeda-cad-model-placement"
 import { generateTypescriptComponent } from "./generate-typescript-component"
 import type { GeneratedComponentType } from "./generate-typescript-component"
 import { isDiodeCategoryComponent } from "./is-diode-category-component"
+import { isInductorComponent } from "./is-inductor-component"
 import { isLedCategoryComponent } from "./is-led-category-component"
 import { isPushbuttonCategoryComponent } from "./is-pushbutton-category-component"
 import { isSwitchCategoryComponent } from "./is-switch-category-component"
@@ -24,6 +25,7 @@ const getGeneratedComponentType = (
   if (isDiodeCategoryComponent(betterEasy)) return "diode"
   if (isPushbuttonCategoryComponent(betterEasy)) return "pushbutton"
   if (isSwitchCategoryComponent(betterEasy)) return "switch"
+  if (isInductorComponent(betterEasy)) return "inductor"
   return "chip"
 }
 
@@ -91,6 +93,10 @@ export const convertBetterEasyToTsx = async ({
     jlcpcb: [betterEasy.lcsc.number],
   }
   const componentType = getGeneratedComponentType(betterEasy)
+  const inductance =
+    componentType === "inductor"
+      ? betterEasy.dataStr.head.c_para.Value?.trim()
+      : undefined
   const symbolTsx =
     componentType === "chip" && hasNonBoxSchematicSymbol(betterEasy)
       ? generateSymbolTsx(betterEasy, circuitJson)
@@ -106,6 +112,7 @@ export const convertBetterEasyToTsx = async ({
     circuitJson,
     supplierPartNumbers,
     componentType,
+    inductance,
     symbolTsx,
   })
 }

--- a/lib/websafe/convert-to-typescript-component/is-inductor-component.ts
+++ b/lib/websafe/convert-to-typescript-component/is-inductor-component.ts
@@ -1,0 +1,15 @@
+import type { BetterEasyEdaJson } from "lib/schemas/easy-eda-json-schema"
+
+const inductancePattern = /^\d+(?:\.\d+)?\s*(?:pH|nH|uH|µH|mH|H)$/i
+
+export const isInductorComponent = (betterEasy: BetterEasyEdaJson): boolean => {
+  const componentParameters = betterEasy.dataStr.head.c_para
+  const packageName = componentParameters.package
+  const value = componentParameters.Value
+
+  return (
+    packageName?.toUpperCase().startsWith("IND-") === true &&
+    typeof value === "string" &&
+    inductancePattern.test(value.trim())
+  )
+}

--- a/tests/convert-to-ts/C2041570-to-ts.test.ts
+++ b/tests/convert-to-ts/C2041570-to-ts.test.ts
@@ -1,13 +1,30 @@
 import { expect, it } from "bun:test"
 import { EasyEdaJsonSchema } from "lib/schemas/easy-eda-json-schema"
 import { convertBetterEasyToTsx } from "lib/websafe/convert-to-typescript-component"
+import { runTscircuitCode } from "tscircuit"
 import inductorRawEasy from "../assets/C2041570.raweasy.json"
 
-it("reproduces C2041570 as a generic chip", async () => {
+it("converts C2041570 to an inductor", async () => {
   const betterEasy = EasyEdaJsonSchema.parse(inductorRawEasy)
   const result = await convertBetterEasyToTsx({ betterEasy })
 
-  expect(result).toContain('import type { ChipProps } from "@tscircuit/props"')
-  expect(result).toContain("<chip")
-  expect(result).not.toContain("<inductor")
+  expect(result).toContain(
+    'import type { InductorProps } from "@tscircuit/props"',
+  )
+  expect(result).toContain('props: Omit<InductorProps, "inductance">')
+  expect(result).toContain("<inductor")
+  expect(result).toContain('inductance="2.2uH"')
+  expect(result).not.toContain("<chip")
+
+  const circuitJson = await runTscircuitCode(result)
+  expect(circuitJson).toContainEqual(
+    expect.objectContaining({
+      type: "source_component",
+      ftype: "simple_inductor",
+      inductance: "2.2uH",
+    }),
+  )
+  expect(
+    circuitJson.filter((element) => element.type.endsWith("_error")),
+  ).toHaveLength(0)
 })


### PR DESCRIPTION
## Summary

- classify EasyEDA parts with an `IND-` package and a valid inductance value as inductors
- generate `<inductor>` with the source record's fixed inductance
- preserve the exact imported footprint, supplier code, and CAD model

## Root cause

The TSX generator had no inductor component type, so C2041570 fell through to the generic chip output even though its EasyEDA package is `IND-SMD_L2.0-W1.6_VLS201610ET` and its value is `2.2uH`.

## Stack

Depends on #436, which contains only the real C2041570 fixture and current-behavior reproduction. This PR changes that focused test to prove the semantic inductor output and successful Circuit JSON evaluation.

The separate exact manufacturer-part-number issue remains scoped to #433; this PR does not duplicate or alter that fix.

## Validation

- focused test: generated TSX contains `<inductor inductance="2.2uH">`
- generated Circuit JSON contains a `simple_inductor` source component and zero error objects
- `bun run format`
- `bun run build`
- full suite: 137 passed, 0 failed
