### PR TITLE
fix: import C1525 capacitors as capacitor primitives

### DIFF
--- a/lib/websafe/convert-to-typescript-component/generate-typescript-component.ts
+++ b/lib/websafe/convert-to-typescript-component/generate-typescript-component.ts
@@ -9,6 +9,7 @@ export type GeneratedComponentType =
   | "led"
   | "pushbutton"
   | "switch"
+  | "capacitor"
   | "inductor"
   | "crystal"
   | "connector"
@@ -22,6 +23,7 @@ interface Params {
   supplierPartNumbers: SupplierPartNumbers
   manufacturerPartNumber: string
   componentType?: GeneratedComponentType
+  capacitance?: string
   inductance?: string
   crystalFrequency?: string
   crystalPinVariant?: "two_pin" | "four_pin"
@@ -37,6 +39,7 @@ export const generateTypescriptComponent = ({
   supplierPartNumbers,
   manufacturerPartNumber,
   componentType = "chip",
+  capacitance,
   inductance,
   crystalFrequency,
   crystalPinVariant,
@@ -212,6 +215,38 @@ export const ${componentName} = (props: SwitchProps) => {
       name={name}
       pinLabels={pinLabels}
 ${symbolProp}\
+      supplierPartNumbers={${JSON.stringify(supplierPartNumbers, null, "  ")}}
+      manufacturerPartNumber="${manufacturerPartNumber}"
+      footprint={${footprintTsx}}
+      ${
+        objUrl || stepUrl
+          ? `cadModel={{
+${cadModelLines}
+      }}`
+          : ""
+      }
+      {...restProps}
+    />
+  )
+}
+`.trim()
+  }
+
+  if (componentType === "capacitor") {
+    if (!capacitance) {
+      throw new Error("Capacitance is required for capacitor components")
+    }
+
+    return `
+import type { CapacitorProps } from "@tscircuit/props"
+
+export const ${componentName} = (props: Omit<CapacitorProps, "capacitance">) => {
+  const { name = "C1", ...restProps } = props
+
+  return (
+    <capacitor
+      name={name}
+      capacitance=${JSON.stringify(capacitance)}
       supplierPartNumbers={${JSON.stringify(supplierPartNumbers, null, "  ")}}
       manufacturerPartNumber="${manufacturerPartNumber}"
       footprint={${footprintTsx}}

--- a/lib/websafe/convert-to-typescript-component/index.tsx
+++ b/lib/websafe/convert-to-typescript-component/index.tsx
@@ -8,7 +8,10 @@ import { normalizeManufacturerPartNumber } from "lib/utils/normalize-manufacture
 import { getEasyEdaCadModelPlacement } from "../get-easyeda-cad-model-placement"
 import { generateTypescriptComponent } from "./generate-typescript-component"
 import type { GeneratedComponentType } from "./generate-typescript-component"
-import { isCapacitorComponent } from "./is-capacitor-component"
+import {
+  isCapacitorComponent,
+  normalizeCapacitanceValue,
+} from "./is-capacitor-component"
 import { isCrystalComponent } from "./is-crystal-component"
 import { isDiodeCategoryComponent } from "./is-diode-category-component"
 import { isInductorComponent } from "./is-inductor-component"
@@ -115,7 +118,7 @@ export const convertBetterEasyToTsx = async ({
       : undefined
   const capacitance =
     componentType === "capacitor"
-      ? betterEasy.dataStr.head.c_para.Value?.trim()
+      ? normalizeCapacitanceValue(betterEasy.dataStr.head.c_para.Value)
       : undefined
   const crystalFrequency =
     componentType === "crystal"

--- a/lib/websafe/convert-to-typescript-component/index.tsx
+++ b/lib/websafe/convert-to-typescript-component/index.tsx
@@ -8,6 +8,7 @@ import { normalizeManufacturerPartNumber } from "lib/utils/normalize-manufacture
 import { getEasyEdaCadModelPlacement } from "../get-easyeda-cad-model-placement"
 import { generateTypescriptComponent } from "./generate-typescript-component"
 import type { GeneratedComponentType } from "./generate-typescript-component"
+import { isCapacitorComponent } from "./is-capacitor-component"
 import { isCrystalComponent } from "./is-crystal-component"
 import { isDiodeCategoryComponent } from "./is-diode-category-component"
 import { isInductorComponent } from "./is-inductor-component"
@@ -28,6 +29,7 @@ const getGeneratedComponentType = (
   if (isDiodeCategoryComponent(betterEasy) && pinCount === 2) return "diode"
   if (isPushbuttonCategoryComponent(betterEasy)) return "pushbutton"
   if (isSwitchCategoryComponent(betterEasy)) return "switch"
+  if (isCapacitorComponent(betterEasy)) return "capacitor"
   if (isInductorComponent(betterEasy)) return "inductor"
   if (isCrystalComponent(betterEasy)) return "crystal"
   if (isMicroUsbConnectorComponent(betterEasy)) return "connector"
@@ -111,6 +113,10 @@ export const convertBetterEasyToTsx = async ({
     componentType === "inductor"
       ? betterEasy.dataStr.head.c_para.Value?.trim()
       : undefined
+  const capacitance =
+    componentType === "capacitor"
+      ? betterEasy.dataStr.head.c_para.Value?.trim()
+      : undefined
   const crystalFrequency =
     componentType === "crystal"
       ? betterEasy.dataStr.head.c_para.Value?.trim()
@@ -142,6 +148,7 @@ export const convertBetterEasyToTsx = async ({
     circuitJson,
     supplierPartNumbers,
     componentType,
+    capacitance,
     inductance,
     crystalFrequency,
     crystalPinVariant,

--- a/lib/websafe/convert-to-typescript-component/is-capacitor-component.ts
+++ b/lib/websafe/convert-to-typescript-component/is-capacitor-component.ts
@@ -1,0 +1,17 @@
+import type { BetterEasyEdaJson } from "lib/schemas/easy-eda-json-schema"
+
+const capacitancePattern = /^\d+(?:\.\d+)?\s*(?:pF|nF|uF|µF|mF|F)$/i
+
+export const isCapacitorComponent = (
+  betterEasy: BetterEasyEdaJson,
+): boolean => {
+  const componentParameters = betterEasy.dataStr.head.c_para
+  const prefix = componentParameters.pre
+  const value = componentParameters.Value
+
+  return (
+    prefix?.toUpperCase() === "C?" &&
+    typeof value === "string" &&
+    capacitancePattern.test(value.trim())
+  )
+}

--- a/lib/websafe/convert-to-typescript-component/is-capacitor-component.ts
+++ b/lib/websafe/convert-to-typescript-component/is-capacitor-component.ts
@@ -1,6 +1,17 @@
 import type { BetterEasyEdaJson } from "lib/schemas/easy-eda-json-schema"
 
-const capacitancePattern = /^\d+(?:\.\d+)?\s*(?:pF|nF|uF|µF|mF|F)$/i
+const capacitancePattern = /^\d+(?:\.\d+)?\s*(?:pF|nF|[uµμ]F|mF|F)$/i
+
+export const normalizeCapacitanceValue = (
+  value: unknown,
+): string | undefined => {
+  if (typeof value !== "string") return undefined
+
+  const trimmedValue = value.trim()
+  if (!capacitancePattern.test(trimmedValue)) return undefined
+
+  return trimmedValue.replace(/\s+/g, "").replace(/[µμ]/g, "u")
+}
 
 export const isCapacitorComponent = (
   betterEasy: BetterEasyEdaJson,
@@ -11,7 +22,6 @@ export const isCapacitorComponent = (
 
   return (
     prefix?.toUpperCase() === "C?" &&
-    typeof value === "string" &&
-    capacitancePattern.test(value.trim())
+    normalizeCapacitanceValue(value) !== undefined
   )
 }

--- a/tests/assets/C1525.raweasy.json
+++ b/tests/assets/C1525.raweasy.json
@@ -1,0 +1,236 @@
+{
+  "uuid": "ca94110f4544769d36adda4b0515e409",
+  "title": "CL05B104KO5NNNC",
+  "description": "100nF (104) ±10% 16V",
+  "docType": 2,
+  "type": 3,
+  "thumb": "//image.easyeda.com/components/ca94110f4544769d36adda4b0515e409.png",
+  "szlcsc": {
+    "id": 1877,
+    "number": "C1525",
+    "step": 100,
+    "min": 100,
+    "price": 0.007514,
+    "stock": 4941800,
+    "url": "http://www.szlcsc.com/product/details_1877.html",
+    "image": "https://assets.lcsc.com/images/szlcsc/96x96/Multilayer-Ceramic-Capacitors-MLCC-SMD-SMT_SAMSUNG_CL05B104KO5NNNC_100nF-104-10-16V_C1525_front_10.jpg"
+  },
+  "lcsc": {
+    "id": 1877,
+    "number": "C1525",
+    "step": 100,
+    "min": 100,
+    "price": 0.0129,
+    "stock": 869375,
+    "url": "https://lcsc.com/product-detail/Multilayer-Ceramic-Capacitors-MLCC-SMD-SMT_SAMSUNG_CL05B104KO5NNNC_100nF-104-10-16V_C1525.html"
+  },
+  "owner": {
+    "uuid": "0819f05c4eef4c71ace90d822a990e87",
+    "username": "LCSC",
+    "nickname": "LCSC",
+    "avatar": "//image.lceda.cn/avatars/2018/6/kFlrasi7W06gTdBLAqW3fkrqbDhbowynuSzkjqso.png"
+  },
+  "tags": [
+    "Multilayer Ceramic Capacitors MLCC - SMD/SMT"
+  ],
+  "updateTime": 1723686711,
+  "updated_at": "2026-08-08 12:44:03",
+  "dataStr": {
+    "head": {
+      "docType": "2",
+      "editorVersion": "6.5.46",
+      "c_para": {
+        "pre": "C?",
+        "name": "CL05B104KO5NNNC",
+        "package": "C0402",
+        "nameAlias": "Value",
+        "Supplier": "LCSC",
+        "Manufacturer Part": "CL05B104KO5NNNC",
+        "Manufacturer": "SAMSUNG(三星)",
+        "Value": "100nF",
+        "Supplier Part": "C1525",
+        "JLCPCB Part Class": "Basic Part"
+      },
+      "x": 10,
+      "y": 20,
+      "puuid": "0821ed6ea50c44f4909e4be7610e4198",
+      "uuid": "ca94110f4544769d36adda4b0515e409",
+      "utime": 1723686711,
+      "importFlag": 0,
+      "c_spiceCmd": null,
+      "hasIdFlag": true
+    },
+    "canvas": "CA~1000~1000~#FFFFFF~yes~#CCCCCC~5~1000~1000~line~5~pixel~5~10~20",
+    "shape": [
+      "PL~8 20 0 20~#A00000~1~0~none~gge26~0",
+      "P~show~0~2~30~20~0~gge29~0^^30~20^^M 20 20 h 10~#800^^0~16~20~0~2~end~~~#800^^0~24~16~0~2~start~~~#800^^0~43~20^^0~M 40 17 L 37 20 L 40 23",
+      "PL~12 12 12 28~#A00000~1~0~none~gge50~0",
+      "PL~20 20 12 20~#A00000~1~0~none~gge53~0",
+      "P~show~0~1~-10~20~180~gge56~0^^-10~20^^M 0 20 h -10~#800^^0~4~20~0~1~start~~~#800^^0~-4~16~0~1~end~~~#800^^0~-23~20^^0~M -20 23 L -17 20 L -20 17",
+      "PL~8 28 8 12~#A00000~1~0~none~gge77~0"
+    ],
+    "BBox": {
+      "x": -11,
+      "y": 12,
+      "width": 42,
+      "height": 16
+    },
+    "colors": []
+  },
+  "verify": true,
+  "SMT": true,
+  "datastrid": "2c0828f24698477189196dcd9aec4345",
+  "jlcOnSale": 1,
+  "writable": false,
+  "isFavorite": false,
+  "packageDetail": {
+    "uuid": "0821ed6ea50c44f4909e4be7610e4198",
+    "title": "C0402",
+    "docType": 4,
+    "updateTime": 1766729395,
+    "owner": {
+      "uuid": "0819f05c4eef4c71ace90d822a990e87",
+      "username": "lcsc",
+      "nickname": "LCSC",
+      "avatar": "//image.lceda.cn/avatars/2018/6/kFlrasi7W06gTdBLAqW3fkrqbDhbowynuSzkjqso.png"
+    },
+    "datastrid": "807a4cd3faaa4931b62b7d7e2a410612",
+    "writable": false,
+    "dataStr": {
+      "head": {
+        "docType": "4",
+        "editorVersion": "6.5.51",
+        "newgId": true,
+        "c_para": {
+          "package": "C0402",
+          "pre": "C?",
+          "Contributor": "lcsc",
+          "link": "https://item.szlcsc.com/15869.html",
+          "3DModel": "C0402_L1.0-W0.5-H0.5"
+        },
+        "hasIdFlag": true,
+        "x": 4000,
+        "y": 3000,
+        "uuid": "0821ed6ea50c44f4909e4be7610e4198",
+        "utime": 1766729391,
+        "importFlag": 0,
+        "transformList": ""
+      },
+      "canvas": "CA~1000~1000~#000000~yes~#FFFFFF~10~1000~1000~line~0.5~mm~1~45~visible~0.5~4000~3000~0~none",
+      "shape": [
+        "CIRCLE~3998.032~3000.984~0.118~0.2362~101~gge1083~0~~",
+        "SOLIDREGION~100~~M 3998.0315 3000.9843 L 3998.0315 2999.0157 L 3999.0157 2999.0157 L 3999.0157 3000.9843 Z ~solid~gge1000~~~~0",
+        "SOLIDREGION~100~~M 4001.9685 3000.9843 L 4001.9685 2999.0157 L 4000.9843 2999.0157 L 4000.9843 3000.9843 Z ~solid~gge1001~~~~0",
+        "SOLIDREGION~99~~M 3998.0315 3000.9843 L 3998.0315 2999.0157 L 4001.9685 2999.0157 L 4001.9685 3000.9843 Z ~solid~gge999~~~~0",
+        "TRACK~0.6~3~~3997.1599 2998.0412 3999.1284 2998.0412~gge1171~0",
+        "TRACK~0.6~3~~3996.5598 3001.3671 3996.5598 2998.6411~gge1168~0",
+        "TRACK~0.6~3~~3999.1284 3001.9671 3997.1599 3001.9671~gge1162~0",
+        "TRACK~0.6~3~~4002.8401 3001.9587 4000.8716 3001.9587~gge1159~0",
+        "TRACK~0.6~3~~4000.8716 2998.033 4002.8401 2998.033~gge1153~0",
+        "TRACK~0.6~3~~4003.4402 2998.6328 4003.4402 3001.3589~gge1147~0",
+        "ARC~0.6~3~~M 4002.8401 2998.0329 A 0.6 0.6 0 0 1 4003.4401 2998.6329~~gge1150~0",
+        "ARC~0.6~3~~M 4003.4401 3001.3589 A 0.6 0.6 0 0 1 4002.8401 3001.9589~~gge1156~0",
+        "ARC~0.6~3~~M 3997.1599 3001.9671 A 0.6 0.6 0 0 1 3996.5599 3001.3671~~gge1165~0",
+        "ARC~0.6~3~~M 3996.5599 2998.6411 A 0.6 0.6 0 0 1 3997.1599 2998.0411~~gge1174~0",
+        "PAD~RECT~4001.654~3000~1.9685~2.126~1~~2~0~4000.6693 2998.937 4002.6378 2998.937 4002.6378 3001.063 4000.6693 3001.063~0~gge1111~0~~Y~0~0~0.2000~4001.6534,3000",
+        "PAD~RECT~3998.346~3000~1.9685~2.126~1~~1~0~3997.3622 2998.937 3999.3307 2998.937 3999.3307 3001.063 3997.3622 3001.063~0~gge1114~0~~Y~0~0~0.2000~3998.3466,3000",
+        "SVGNODE~{\"gId\":\"g1_outline\",\"nodeName\":\"g\",\"nodeType\":1,\"layerid\":\"19\",\"attrs\":{\"c_width\":\"3.937\",\"c_height\":\"1.9685\",\"c_rotation\":\"0,0,0\",\"z\":\"0\",\"c_origin\":\"4000,3000\",\"uuid\":\"32fe2cf9314f444ca2785a33c2db7189\",\"c_etype\":\"outline3D\",\"id\":\"g1_outline\",\"title\":\"C0402_L1.0-W0.5-H0.5\",\"layerid\":\"19\",\"transform\":\"scale(1) translate(0, 0)\"},\"childNodes\":[{\"gId\":\"g1_outline_line0\",\"nodeName\":\"polyline\",\"nodeType\":1,\"attrs\":{\"fill\":\"none\",\"id\":\"g1_outline_line0\",\"c_shapetype\":\"line\",\"points\":\"3998.0315 2999.0551 3998.0315 2999.0945 3998.0315 3000.9449 3998.0708 3000.9449 3998.0708 3000.9842 3998.1102 3000.9842 3998.8976 3000.9842 3998.9763 3000.9842 3999.0157 3000.9842 3999.0157 3000.9449 4000.9842 3000.9449 4000.9842 3000.9842 4001.0236 3000.9842 4001.1023 3000.9842 4001.8897 3000.9842 4001.9291 3000.9842 4001.9291 3000.9449 4001.9685 3000.9055 4001.9685 3000 4001.9685 2999.0551 4001.9291 2999.0551 4001.9291 2999.0157 4001.8897 2999.0157 4001.1023 2999.0157 4001.0629 2999.0157 4001.0236 2999.0157 4000.9842 2999.0157 4000.9842 2999.0551 3999.0157 2999.0551 3999.0157 2999.0157 3998.9763 2999.0157 3998.8976 2999.0157 3998.1102 2999.0157 3998.0708 2999.0157 3998.0708 2999.0551 3998.0315 2999.0551 3998.0315 2999.0551\"}}]}"
+      ],
+      "layers": [
+        "1~TopLayer~#FF0000~true~false~true~",
+        "2~BottomLayer~#0000FF~true~false~true~",
+        "3~TopSilkLayer~#FFCC00~true~false~true~",
+        "4~BottomSilkLayer~#66CC33~true~false~true~",
+        "5~TopPasteMaskLayer~#808080~true~true~true~",
+        "6~BottomPasteMaskLayer~#800000~true~false~true~",
+        "7~TopSolderMaskLayer~#800080~true~false~true~0.3",
+        "8~BottomSolderMaskLayer~#AA00FF~true~false~true~0.3",
+        "9~Ratlines~#6464FF~true~false~true~",
+        "10~BoardOutLine~#FF00FF~true~false~true~",
+        "11~Multi-Layer~#FFFFFF~true~false~true~0.5",
+        "12~Document~#FFFFFF~true~false~true~",
+        "13~TopAssembly~#33CC99~true~false~true~",
+        "14~BottomAssembly~#5555FF~true~false~true~",
+        "15~Mechanical~#F022F0~true~false~true~",
+        "19~3DModel~#66CCFF~true~false~true~",
+        "21~Inner1~#800000~false~false~false~~",
+        "22~Inner2~#008000~false~false~false~~",
+        "23~Inner3~#00FF00~false~false~false~~",
+        "24~Inner4~#BC8E00~false~false~false~~",
+        "25~Inner5~#70DBFA~false~false~false~~",
+        "26~Inner6~#00CC66~false~false~false~~",
+        "27~Inner7~#9966FF~false~false~false~~",
+        "28~Inner8~#800080~false~false~false~~",
+        "29~Inner9~#008080~false~false~false~~",
+        "30~Inner10~#15935F~false~false~false~~",
+        "31~Inner11~#000080~false~false~false~~",
+        "32~Inner12~#00B400~false~false~false~~",
+        "33~Inner13~#2E4756~false~false~false~~",
+        "34~Inner14~#99842F~false~false~false~~",
+        "35~Inner15~#FFFFAA~false~false~false~~",
+        "36~Inner16~#99842F~false~false~false~~",
+        "37~Inner17~#2E4756~false~false~false~~",
+        "38~Inner18~#3535FF~false~false~false~~",
+        "39~Inner19~#8000BC~false~false~false~~",
+        "40~Inner20~#43AE5F~false~false~false~~",
+        "41~Inner21~#C3ECCE~false~false~false~~",
+        "42~Inner22~#728978~false~false~false~~",
+        "43~Inner23~#39503F~false~false~false~~",
+        "44~Inner24~#0C715D~false~false~false~~",
+        "45~Inner25~#5A8A80~false~false~false~~",
+        "46~Inner26~#2B937E~false~false~false~~",
+        "47~Inner27~#23999D~false~false~false~~",
+        "48~Inner28~#45B4E3~false~false~false~~",
+        "49~Inner29~#215DA1~false~false~false~~",
+        "50~Inner30~#4564D7~false~false~false~~",
+        "51~Inner31~#6969E9~false~false~false~~",
+        "52~Inner32~#9069E9~false~false~false~~",
+        "99~ComponentShapeLayer~#00CCCC~true~false~true~0.4",
+        "100~LeadShapeLayer~#CC9999~true~false~true~",
+        "101~ComponentPolarityLayer~#66FFCC~true~false~true~",
+        "Hole~Hole~#222222~false~false~true~",
+        "DRCError~DRCError~#FAD609~false~false~true~"
+      ],
+      "objects": [
+        "All~true~false",
+        "Component~true~true",
+        "Prefix~true~true",
+        "Name~true~false",
+        "Track~true~true",
+        "Pad~true~true",
+        "Via~true~true",
+        "Hole~true~true",
+        "Copper_Area~true~true",
+        "Circle~true~true",
+        "Arc~true~true",
+        "Solid_Region~true~true",
+        "Text~true~true",
+        "Image~true~true",
+        "Rect~true~true",
+        "Dimension~true~true",
+        "Protractor~true~true"
+      ],
+      "BBox": {
+        "x": 3996.6,
+        "y": 2998,
+        "width": 6.9,
+        "height": 3.9
+      },
+      "netColors": []
+    }
+  },
+  "_objMetadata": {
+    "bounds": {
+      "min": {
+        "x": -0.5,
+        "y": -0.25,
+        "z": -0.25
+      },
+      "max": {
+        "x": 0.5,
+        "y": 0.25,
+        "z": 0.25
+      }
+    }
+  }
+}

--- a/tests/convert-to-ts/C1525-to-ts.test.ts
+++ b/tests/convert-to-ts/C1525-to-ts.test.ts
@@ -4,6 +4,30 @@ import { EasyEdaJsonSchema } from "lib/schemas/easy-eda-json-schema"
 import { runTscircuitCode } from "tscircuit"
 import capacitorRawEasy from "../assets/C1525.raweasy.json"
 
+for (const microSymbol of [
+  { character: "µ", codePoint: "U+00B5" },
+  { character: "μ", codePoint: "U+03BC" },
+]) {
+  it(`normalizes the ${microSymbol.codePoint} micro symbol`, async () => {
+    const rawEasy = structuredClone(capacitorRawEasy)
+    rawEasy.dataStr.head.c_para.Value = `1${microSymbol.character}F`
+    const betterEasy = EasyEdaJsonSchema.parse(rawEasy)
+    const result = await convertBetterEasyToTsx({ betterEasy })
+
+    expect(result).toContain("<capacitor")
+    expect(result).toContain('capacitance="1uF"')
+
+    const circuitJson = await runTscircuitCode(result)
+    expect(circuitJson).toContainEqual(
+      expect.objectContaining({
+        type: "source_component",
+        ftype: "simple_capacitor",
+        capacitance: 1e-6,
+      }),
+    )
+  })
+}
+
 it("converts C1525 to a capacitor with its exact footprint", async () => {
   const betterEasy = EasyEdaJsonSchema.parse(capacitorRawEasy)
   const result = await convertBetterEasyToTsx({ betterEasy })

--- a/tests/convert-to-ts/C1525-to-ts.test.ts
+++ b/tests/convert-to-ts/C1525-to-ts.test.ts
@@ -1,0 +1,51 @@
+import { expect, it } from "bun:test"
+import { convertBetterEasyToTsx } from "lib/websafe/convert-to-typescript-component"
+import { EasyEdaJsonSchema } from "lib/schemas/easy-eda-json-schema"
+import { runTscircuitCode } from "tscircuit"
+import capacitorRawEasy from "../assets/C1525.raweasy.json"
+
+it("converts C1525 to a capacitor with its exact footprint", async () => {
+  const betterEasy = EasyEdaJsonSchema.parse(capacitorRawEasy)
+  const result = await convertBetterEasyToTsx({ betterEasy })
+
+  expect(result).toContain(
+    'import type { CapacitorProps } from "@tscircuit/props"',
+  )
+  expect(result).toContain('props: Omit<CapacitorProps, "capacitance">')
+  expect(result).toContain("<capacitor")
+  expect(result).toContain('capacitance="100nF"')
+  expect(result).not.toContain("<chip")
+  expect(result).not.toContain("ChipProps")
+  expect(result).not.toContain("<symbol")
+  expect(result).toContain('manufacturerPartNumber="CL05B104KO5NNNC"')
+  expect(result).toContain('"C1525"')
+  expect(result.match(/<smtpad /g)).toHaveLength(2)
+  expect(result).toContain(
+    '<smtpad portHints={["pin1"]} pcbX="-0.420116mm" pcbY="0mm" width="0.499999mm" height="0.540004mm" shape="rect" />',
+  )
+  expect(result).toContain(
+    '<smtpad portHints={["pin2"]} pcbX="0.420116mm" pcbY="0mm" width="0.499999mm" height="0.540004mm" shape="rect" />',
+  )
+
+  const circuitJson = await runTscircuitCode(result)
+  expect(circuitJson).toContainEqual(
+    expect.objectContaining({
+      type: "source_component",
+      ftype: "simple_capacitor",
+      capacitance: 1e-7,
+      display_capacitance: "100nF",
+      name: "C1",
+      manufacturer_part_number: "CL05B104KO5NNNC",
+      supplier_part_numbers: { jlcpcb: ["C1525"] },
+    }),
+  )
+  expect(
+    circuitJson.filter((element) => element.type === "source_port"),
+  ).toHaveLength(2)
+  expect(
+    circuitJson.filter((element) => element.type === "pcb_smtpad"),
+  ).toHaveLength(2)
+  expect(
+    circuitJson.filter((element) => element.type.endsWith("_error")),
+  ).toHaveLength(0)
+})


### PR DESCRIPTION
## Summary

- recognize capacitor metadata with a capacitor reference prefix and capacitance-valued `Value`
- generate `<capacitor>` components with `CapacitorProps` and the parsed capacitance
- preserve the imported EasyEDA footprint, supplier part number, manufacturer part number, and CAD model
- avoid carrying the EasyEDA custom schematic symbol into capacitor primitives
- add the canonical C1525 EasyEDA fixture and a regression test

## Root cause

The TypeScript converter had specialized generation paths for inductors, diodes, LEDs, switches, and other primitives, but not capacitors. C1525 therefore fell through to the generic chip path, producing `ChipProps`, `<chip>`, and an imported custom symbol instead of a capacitor primitive.

## Impact

`bunx tsci import C1525 --jlcpcb --use-exact-footprint` now generates CL05B104KO5NNNC as a 100 nF capacitor with two ports and the exact two-pad C0402 footprint.

## Validation

- `bun test tests/convert-to-ts/C1525-to-ts.test.ts`
- `bun test tests/convert-to-ts/C1525-to-ts.test.ts tests/convert-to-ts/C2041570-to-ts.test.ts tests/convert-to-ts/C57759-to-led.test.ts tests/convert-to-ts/C57759-to-ts.test.ts tests/convert-to-ts/C404969-to-ts.test.ts`
- `bunx tsc --noEmit`
- `bun run build`
- `bun run format:check`
- `git diff --check`

One unrelated existing 3D snapshot test for C139797 could not download its model from the CDN in the local sandbox; the focused and related non-network tests pass.