### PR TITLE
Handle malformed EasyEDA schema variants

### DIFF
--- a/lib/schemas/easy-eda-json-schema.ts
+++ b/lib/schemas/easy-eda-json-schema.ts
@@ -11,7 +11,12 @@ export const maybeNumber = z
   .pipe(z.number().nullable().optional())
 
 export const SzlcscSchema = z.object({
-  id: z.number(),
+  id: z.preprocess((value) => {
+    if (typeof value === "string" && /^\d+$/.test(value)) {
+      return Number(value)
+    }
+    return value
+  }, z.number()),
   number: z.string(),
   step: z.number().optional(),
   min: z.number().optional(),
@@ -47,10 +52,10 @@ export const HeadSchema = z.object({
   puuid: z.string().optional(),
   uuid: z.string(),
   utime: z.preprocess((val) => {
-    if (val === "") return 0
+    if (val == null || val === "") return undefined
     if (typeof val === "string") return Number(val)
     return val
-  }, z.number()),
+  }, z.number().optional()),
   importFlag: z.number().optional(),
   c_spiceCmd: z.any().optional(),
   hasIdFlag: z.boolean().default(false),

--- a/lib/schemas/single-letter-shape-schema.ts
+++ b/lib/schemas/single-letter-shape-schema.ts
@@ -402,7 +402,8 @@ const parseText = (str: string): z.input<typeof TextShapeOutputSchema> => {
 
   return {
     type: "TEXT",
-    alignment: alignment as "L" | "C" | "R",
+    // Some EasyEDA component payloads use "P" for start-aligned text.
+    alignment: (alignment === "P" ? "L" : alignment) as "L" | "C" | "R",
     x: Number(x),
     y: Number(y),
     rotation: Number(rotation),

--- a/tests/parse-tests/malformed-schema-variants.test.ts
+++ b/tests/parse-tests/malformed-schema-variants.test.ts
@@ -1,0 +1,40 @@
+import { expect, it } from "bun:test"
+import { EasyEdaJsonSchema } from "lib/schemas/easy-eda-json-schema"
+import C113367EasyEdaJson from "../assets/C113367.raweasy.json"
+import C124352EasyEdaJson from "../assets/C124352.raweasy.json"
+
+it("coerces a numeric-string szlcsc id", () => {
+  const payload: any = structuredClone(C124352EasyEdaJson)
+  payload.szlcsc.id = String(payload.szlcsc.id)
+
+  const result = EasyEdaJsonSchema.parse(payload)
+
+  expect(result.szlcsc.id).toBe(C124352EasyEdaJson.szlcsc.id)
+})
+
+it.each([undefined, null, ""])(
+  "accepts an absent dataStr.head.utime value (%s)",
+  (utime) => {
+    const payload: any = structuredClone(C124352EasyEdaJson)
+    payload.dataStr.head.utime = utime
+
+    const result = EasyEdaJsonSchema.parse(payload)
+
+    expect(result.dataStr.head.utime).toBeUndefined()
+  },
+)
+
+it('normalizes text alignment "P" to left alignment', () => {
+  const payload: any = structuredClone(C113367EasyEdaJson)
+  const textShapeIndex = payload.dataStr.shape.findIndex((shape: string) =>
+    shape.startsWith("T~"),
+  )
+  payload.dataStr.shape[textShapeIndex] = payload.dataStr.shape[
+    textShapeIndex
+  ].replace(/^T~[LCR]~/, "T~P~")
+
+  const result = EasyEdaJsonSchema.parse(payload)
+  const textShape = result.dataStr.shape.find((shape) => shape.type === "TEXT")
+
+  expect(textShape?.alignment).toBe("L")
+})


### PR DESCRIPTION
## Summary

- coerce digit-only string values for `szlcsc.id` to numbers
- treat missing, null, and empty `dataStr.head.utime` metadata as absent
- normalize EasyEDA text alignment `P` (start-aligned text) to left alignment
- add focused regression coverage for all three payload families

## Root cause

`EasyEdaJsonSchema` modeled these upstream fields more narrowly than the variants returned by EasyEDA, so conversion stopped during schema validation and downstream indexers retried the same payloads.

## Impact

The affected component payloads can now reach conversion while malformed values outside these explicitly safe normalizations remain rejected.

## Validation

- `bun test tests/parse-tests/malformed-schema-variants.test.ts`
- `bun run build`
- `bun test` (159 passed)
- parsed the live reproduction payloads for C53562, C110074, and C2879807

Closes #454