### PR TITLE
Fix EasyEDA through-hole layer modeling in tscircuit.com previews

### DIFF
--- a/lib/convert-easyeda-json-to-tscircuit-soup-json.ts
+++ b/lib/convert-easyeda-json-to-tscircuit-soup-json.ts
@@ -409,7 +409,8 @@ export const convertEasyEdaJsonToCircuitJson = (
         pcb_plated_hole_id: platedHoleId,
         x: mil2mm(pad.center.x),
         y: mil2mm(pad.center.y),
-        layers: ["top"],
+        // Through-hole pads are plated on both outer copper layers.
+        layers: ["top", "bottom"],
         port_hints: pcbPortHints,
         pcb_component_id: "pcb_component_1",
         pcb_port_id: `pcb_port_${index + 1}`,

--- a/tests/convert-to-soup-tests/plated-hole-layers.test.ts
+++ b/tests/convert-to-soup-tests/plated-hole-layers.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test"
+import { su } from "@tscircuit/circuit-json-util"
+import { EasyEdaJsonSchema } from "lib/schemas/easy-eda-json-schema"
+import { convertEasyEdaJsonToCircuitJson } from "lib/convert-easyeda-json-to-tscircuit-soup-json"
+import rawEasyEdaJson from "../assets/C75749.raweasy.json"
+
+test("through-hole pads span both outer copper layers", () => {
+  const circuitJson = convertEasyEdaJsonToCircuitJson(
+    EasyEdaJsonSchema.parse(rawEasyEdaJson),
+  )
+  const platedHoles = su(circuitJson).pcb_plated_hole.list()
+
+  expect(platedHoles.length).toBeGreaterThan(0)
+  expect(platedHoles.every((hole) => hole.layers.includes("top"))).toBe(true)
+  expect(platedHoles.every((hole) => hole.layers.includes("bottom"))).toBe(
+    true,
+  )
+})

--- a/tests/convert-to-soup-tests/plated-hole-layers.test.ts
+++ b/tests/convert-to-soup-tests/plated-hole-layers.test.ts
@@ -12,7 +12,5 @@ test("through-hole pads span both outer copper layers", () => {
 
   expect(platedHoles.length).toBeGreaterThan(0)
   expect(platedHoles.every((hole) => hole.layers.includes("top"))).toBe(true)
-  expect(platedHoles.every((hole) => hole.layers.includes("bottom"))).toBe(
-    true,
-  )
+  expect(platedHoles.every((hole) => hole.layers.includes("bottom"))).toBe(true)
 })


### PR DESCRIPTION
## Summary

Fixes a real `tscircuit.com` Import Component preview bug for JLCPCB/EasyEDA through-hole parts.

When users switched the PCB preview to the bottom layer, plated through-holes continued to appear as top-layer pads instead of rendering as bottom-layer copper. This made imported components look incorrect during preview and could lead to importing an incorrectly understood footprint.

## Root cause

The EasyEDA-to-Circuit-JSON converter modeled every imported plated hole with only:

```ts
layers: ["top"]
```

The PCB viewer's layer switch was working correctly; the generated Circuit JSON was missing the bottom copper layer. The code editor path did not expose the issue because it uses a different tscircuit generation path.

## Fix

Through-hole plated pads now correctly span both outer copper layers:

```ts
layers: ["top", "bottom"]
```

A regression test uses the reported `C75749` fixture and verifies that every converted plated hole includes both `top` and `bottom`.

## User impact

This restores correct top/bottom layer rendering in the tscircuit.com component import preview and keeps imported through-hole footprints consistent with their physical plated-hole construction.

## Validation

- Regression test passes with the `C75749` fixture.
- TypeScript typecheck passes.
- The formatter passes.
- The original preview behavior is documented below.

## Bug in tscircuit.com

<img width="1177" height="592" alt="image" src="https://github.com/user-attachments/assets/891aefc0-7e9b-4e28-8b6d-c03aa86d0610" />

The screenshot shows the preview set to `layer: bottom` while the plated holes remain rendered as top-layer pads.