### PR TITLE
Fix CLI TypeScript conversion for raw EasyEDA JSON

### DIFF
--- a/lib/convert-easyeda-json-to-various-formats.ts
+++ b/lib/convert-easyeda-json-to-various-formats.ts
@@ -84,7 +84,7 @@ export const convertEasyEdaJsonToVariousFormats = async ({
       outputFilename.endsWith(".tsx") ||
       outputFilename.endsWith(".ts")
     ) {
-      const tsComp = await convertRawEasyToTsx(rawEasyEdaJson)
+      const tsComp = await convertRawEasyToTsx({ rawEasy: rawEasyEdaJson })
       await fs.writeFile(outputFilename, tsComp)
       console.log(
         `[${jlcpcbPartNumberOrFilepath}] Saved TypeScript component: ${outputFilename}`,


### PR DESCRIPTION
## Summary

Fixes CLI conversion to `.ts` and `.tsx` outputs.

The original `convertRawEasyToTsx` function was changed to accept the raw EasyEDA payload under a `rawEasy` property, but the CLI call site was not updated at the same time. As a result, the CLI passed the payload directly and TypeScript component generation failed at runtime.

## Verification

- `bun run build`
- Verified CLI conversion from a raw EasyEDA fixture to `.tsx`