### PR TITLE
ci: migrate npm publishing to OIDC

### DIFF
--- a/.github/workflows/pver-release.yml
+++ b/.github/workflows/pver-release.yml
@@ -3,20 +3,24 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
+          package-manager-cache: false
       - name: Use bun
         uses: oven-sh/setup-bun@v1
       - run: npm install -g pver
       - run: bun install --frozen-lockfile
       - run: bun run build
       - run: pver release
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- grant the release workflow GitHub OIDC permissions
- upgrade release builds to setup-node v6 and Node 24
- remove the long-lived npm publishing token
- ensure npm provenance can match this GitHub repository

## npm trusted publisher

Package: easyeda
Repository: tscircuit/easyeda-converter
Workflow: pver-release.yml
Allowed action: npm publish

## Validation

- release workflow YAML parses successfully
- package.json parses successfully
- git diff --check passes
- no NPM_TOKEN or NODE_AUTH_TOKEN reference remains in the release workflow