### PR TITLE
Document real L0805 inductor reproductions

### DIFF
--- a/tests/assets/l0805-inductor-sources.md
+++ b/tests/assets/l0805-inductor-sources.md
@@ -1,0 +1,10 @@
+# L0805 inductor fixture provenance
+
+The L0805 regression uses complete EasyEDA/LCSC component records already stored in this repository, rather than constructed component data.
+
+| Fixture | Real part | EasyEDA UUID | Source listing | SHA-256 |
+| --- | --- | --- | --- | --- |
+| `C1046.raweasy.json` | Sunlord SDFL2012S100KTF, 10uH | `7e7bd4480f50e43c3f271086aa8e152e` | `https://lcsc.com/product-detail/Inductors-SMD_10uH-10_C1046.html` | `c561d07440361f6303a8cc878196cffd58b8f5d2b53b7ce6a36225a1e35fa441` |
+| `C281113.raweasy.json` | microgate MGFL2012F100MT-LF, 10uH | `910aaef3ba604a9a8f17fc3b542dced9` | `https://lcsc.com/product-detail/Inductors-SMD_microgate-MGFL2012F100MT-LF_C281113.html` | `4905c3f850b4aeb964d5a4ff35ca5b9f69e8c1394c63035d079e6b35753a285d` |
+
+Each JSON record contains the original symbol, package, footprint, supplier fields, and 3D model metadata. The regression executes the generated component and snapshots its complete schematic and PCB output.

--- a/tests/convert-to-ts/l0805-inductors-detected-as-chips.test.ts
+++ b/tests/convert-to-ts/l0805-inductors-detected-as-chips.test.ts
@@ -40,6 +40,15 @@ const runReproCase = async (partNumber: string, rawEasy: unknown) => {
 }
 
 test("reproduces C1046 L0805 inductor being generated as a generic chip", async () => {
+  expect(c1046RawEasy).toMatchObject({
+    owner: { username: "LCSC" },
+    title: "SDFL2012S100KTF",
+    uuid: "7e7bd4480f50e43c3f271086aa8e152e",
+    lcsc: {
+      number: "C1046",
+      url: "https://lcsc.com/product-detail/Inductors-SMD_10uH-10_C1046.html",
+    },
+  })
   const result = await runReproCase("C1046", c1046RawEasy)
 
   expect(result).toMatchInlineSnapshot(`
@@ -92,6 +101,15 @@ test("reproduces C1046 L0805 inductor being generated as a generic chip", async 
 }, 50000)
 
 test("reproduces C281113 L0805 inductor being generated as a generic chip", async () => {
+  expect(c281113RawEasy).toMatchObject({
+    owner: { username: "LCSC" },
+    title: "MGFL2012F100MT-LF",
+    uuid: "910aaef3ba604a9a8f17fc3b542dced9",
+    lcsc: {
+      number: "C281113",
+      url: "https://lcsc.com/product-detail/Inductors-SMD_microgate-MGFL2012F100MT-LF_C281113.html",
+    },
+  })
   const result = await runReproCase("C281113", c281113RawEasy)
 
   expect(result).toMatchInlineSnapshot(`


### PR DESCRIPTION
## Reproduction

This PR strengthens the existing regression with provenance and exact source-identity checks for two complete real EasyEDA/LCSC component records: C1046 and C281113.

Both records contain their original inductor symbol, L0805 footprint, supplier/manufacturer metadata, and 3D model data. Their complete generated schematic and PCB snapshots already show the current bug: valid `L?`, `L0805`, `10uH` parts are emitted as generic chips.

No converter behavior changes in this PR.

## Verification

- `bun test tests/convert-to-ts/l0805-inductors-detected-as-chips.test.ts --timeout 50000`
- `bun run format`
- `bunx tsc --noEmit`

Stacked fix: #532
