### PR TITLE
test: reproduce ambiguous EasyEDA search failures for S4

### DIFF
--- a/tests/assets/C41411351.search.json
+++ b/tests/assets/C41411351.search.json
@@ -1,0 +1,28 @@
+{
+  "success": true,
+  "code": 0,
+  "result": {
+    "facets": {
+      "mine": 0,
+      "lcsc": 0,
+      "SMT": 0,
+      "easyeda": 0,
+      "following": 0,
+      "user": 0
+    },
+    "lists": {
+      "lcsc": [],
+      "easyeda": [],
+      "mine": [],
+      "following": [],
+      "user": [],
+      "SMT": []
+    },
+    "pageSize": 100,
+    "totalPage": 0,
+    "wd": "c41411351",
+    "uid": "0819f05c4eef4c71ace90d822a990e87",
+    "type": "3",
+    "doctype": ["2"]
+  }
+}

--- a/tests/fetch-tests/__snapshots__/missing-library-component.test.ts.snap
+++ b/tests/fetch-tests/__snapshots__/missing-library-component.test.ts.snap
@@ -1,0 +1,5 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`reports when S4 has no EasyEDA library search result 1`] = `"Component not found"`;
+
+exports[`reports when EasyEDA rejects the search request 1`] = `"Component not found"`;

--- a/tests/fetch-tests/missing-library-component.test.ts
+++ b/tests/fetch-tests/missing-library-component.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test"
+import { fetchEasyEDAComponent } from "lib/websafe/fetch-easyeda-json"
+import s4SearchResponse from "../assets/C41411351.search.json"
+
+test.each([
+  {
+    name: "S4 has no EasyEDA library search result",
+    response: s4SearchResponse,
+  },
+  {
+    name: "EasyEDA rejects the search request",
+    response: { success: false, code: 500, message: "Search unavailable" },
+  },
+])("reports when $name", async ({ response }) => {
+  const requests: string[] = []
+  const fetch = Object.assign(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = new Request(input, init)
+      requests.push(request.url)
+      expect(request.method).toBe("POST")
+      expect(new URLSearchParams(await request.text()).get("wd")).toBe(
+        "C41411351",
+      )
+      return Response.json(response)
+    },
+    { preconnect: globalThis.fetch.preconnect },
+  )
+
+  await expect(
+    fetchEasyEDAComponent("C41411351", { fetch }),
+  ).rejects.toThrowErrorMatchingSnapshot()
+  // A failed lookup must not fetch another part or fabricate geometry.
+  expect(requests).toEqual(["https://easyeda.com/api/components/search"])
+})


### PR DESCRIPTION
Records the current importer error for the exact S4 part C41411351 using the captured EasyEDA search response from [the S4 audit](https://github.com/AnasSarkiz/Game-Boy-Enhance/tree/main/s4). A successful search with no library entries and an API rejection both produce `Component not found`.

This is the before PR; the fix is stacked in #549. Two offline error snapshots preserve the existing behavior and assertions verify that neither failure fetches a substitute component. The supplier response is retained as a fixture, with formatting only.

Validation: both new tests and snapshots pass; repository formatting and TypeScript checks pass. All GitHub workflows pass (test matrix, formatting and type check).

This PR does not unblock S4 placement. On 2026-09-06, the exact standard product endpoint returned code 404, the supplier SVG endpoint returned code 422 (`原理图未绘制`, schematic not drawn), and the Pro device lookup returned an empty list. No replacement footprint or board geometry is introduced.