### PR TITLE
fix: emit valid JSX for footprint text with quotes and entities

### DIFF
--- a/lib/websafe/generate-footprint-tsx.ts
+++ b/lib/websafe/generate-footprint-tsx.ts
@@ -21,8 +21,16 @@ const getLayerAttr = (layer: LayerRef | undefined) =>
 const getRotationAttr = (rotation: number | undefined) =>
   rotation ? ` pcbRotation="${rotation}deg"` : ""
 
-const getStringAttr = (name: string, value: string | undefined) =>
-  value === undefined ? "" : ` ${name}=${JSON.stringify(value)}`
+const needsJsxStringExpression = (value: string) =>
+  JSON.stringify(value) !== `"${value}"` || value.includes("&")
+
+const getStringAttr = (name: string, value: string | undefined) => {
+  if (value === undefined) return ""
+  if (needsJsxStringExpression(value)) {
+    return ` ${name}={${JSON.stringify(value)}}`
+  }
+  return ` ${name}=${JSON.stringify(value)}`
+}
 
 export const generateFootprintTsx = (
   circuitJson: AnyCircuitElement[],
@@ -149,16 +157,11 @@ export const generateFootprintTsx = (
   }
 
   for (const silkscreenText of silkscreenTexts) {
-    // Preserve the "{NAME}" placeholder so the runtime/editor can resolve it
-    const isRefDes = silkscreenText.text === "{NAME}"
-    const textValue = isRefDes
-      ? JSON.stringify("{NAME}")
-      : JSON.stringify(silkscreenText.text)
     const rotation = silkscreenText.ccw_rotation || 0
     const rotationAttr = rotation ? ` pcbRotation="${rotation}deg"` : ""
 
     elementStrings.push(
-      `<silkscreentext text=${textValue} pcbX="${mmStr(silkscreenText.anchor_position.x)}" pcbY="${mmStr(silkscreenText.anchor_position.y)}" anchorAlignment="${silkscreenText.anchor_alignment}"${rotationAttr}${silkscreenText.font_size ? ` fontSize="${mmStr(silkscreenText.font_size)}"` : ""} />`,
+      `<silkscreentext${getStringAttr("text", silkscreenText.text)} pcbX="${mmStr(silkscreenText.anchor_position.x)}" pcbY="${mmStr(silkscreenText.anchor_position.y)}" anchorAlignment="${silkscreenText.anchor_alignment}"${rotationAttr}${silkscreenText.font_size ? ` fontSize="${mmStr(silkscreenText.font_size)}"` : ""} />`,
     )
   }
 
@@ -170,7 +173,7 @@ export const generateFootprintTsx = (
 
   for (const fabricationNoteText of fabricationNoteTexts) {
     elementStrings.push(
-      `<fabricationnotetext text=${JSON.stringify(fabricationNoteText.text)} pcbX="${mmStr(fabricationNoteText.anchor_position.x)}" pcbY="${mmStr(fabricationNoteText.anchor_position.y)}" anchorAlignment="${fabricationNoteText.anchor_alignment}"${getStringAttr("font", fabricationNoteText.font)}${fabricationNoteText.font_size === undefined ? "" : ` fontSize="${mmStr(fabricationNoteText.font_size)}"`}${getStringAttr("color", fabricationNoteText.color)}${getRotationAttr(fabricationNoteText.ccw_rotation)}${getLayerAttr(fabricationNoteText.layer)} />`,
+      `<fabricationnotetext${getStringAttr("text", fabricationNoteText.text)} pcbX="${mmStr(fabricationNoteText.anchor_position.x)}" pcbY="${mmStr(fabricationNoteText.anchor_position.y)}" anchorAlignment="${fabricationNoteText.anchor_alignment}"${getStringAttr("font", fabricationNoteText.font)}${fabricationNoteText.font_size === undefined ? "" : ` fontSize="${mmStr(fabricationNoteText.font_size)}"`}${getStringAttr("color", fabricationNoteText.color)}${getRotationAttr(fabricationNoteText.ccw_rotation)}${getLayerAttr(fabricationNoteText.layer)} />`,
     )
   }
 
@@ -192,7 +195,7 @@ export const generateFootprintTsx = (
 
   for (const pcbNoteText of pcbNoteTexts) {
     elementStrings.push(
-      `<pcbnotetext text=${JSON.stringify(pcbNoteText.text ?? "")} pcbX="${mmStr(pcbNoteText.anchor_position.x)}" pcbY="${mmStr(pcbNoteText.anchor_position.y)}" anchorAlignment="${pcbNoteText.anchor_alignment}"${getStringAttr("font", pcbNoteText.font)}${pcbNoteText.font_size === undefined ? "" : ` fontSize="${mmStr(pcbNoteText.font_size)}"`}${getStringAttr("color", pcbNoteText.color)}${getLayerAttr(pcbNoteText.layer)} />`,
+      `<pcbnotetext${getStringAttr("text", pcbNoteText.text ?? "")} pcbX="${mmStr(pcbNoteText.anchor_position.x)}" pcbY="${mmStr(pcbNoteText.anchor_position.y)}" anchorAlignment="${pcbNoteText.anchor_alignment}"${getStringAttr("font", pcbNoteText.font)}${pcbNoteText.font_size === undefined ? "" : ` fontSize="${mmStr(pcbNoteText.font_size)}"`}${getStringAttr("color", pcbNoteText.color)}${getLayerAttr(pcbNoteText.layer)} />`,
     )
   }
 

--- a/tests/generate-footprint-tsx.test.ts
+++ b/tests/generate-footprint-tsx.test.ts
@@ -162,3 +162,75 @@ it("preserves fabrication and user notes in generated footprints", async () => {
     circuitJson.find((element) => element.type === "pcb_fabrication_note_text"),
   ).toMatchObject({ text: "+" })
 })
+
+it("emits valid JSX for quotes, entities, and {NAME}", async () => {
+  const cases = [
+    {
+      type: "pcb_silkscreen_text" as const,
+      text: 'Connector 1/4"',
+      expectedJsx: `text={"Connector 1/4\\""}`,
+      roundTrip: true,
+    },
+    {
+      type: "pcb_fabrication_note_text" as const,
+      text: "&amp;",
+      expectedJsx: `text={"&amp;"}`,
+      roundTrip: true,
+    },
+    {
+      type: "pcb_note_text" as const,
+      text: "&#65;",
+      expectedJsx: `text={"&#65;"}`,
+      roundTrip: true,
+    },
+    {
+      type: "pcb_silkscreen_text" as const,
+      text: "{NAME}",
+      expectedJsx: `text="{NAME}"`,
+      roundTrip: false,
+    },
+    {
+      type: "pcb_fabrication_note_dimension" as const,
+      text: '1/4"\nwide',
+      expectedJsx: `text={"1/4\\"\\nwide"}`,
+      roundTrip: true,
+    },
+  ]
+
+  for (const testCase of cases) {
+    const footprint = generateFootprintTsx([
+      testCase.type === "pcb_fabrication_note_dimension"
+        ? ({
+            type: "pcb_fabrication_note_dimension",
+            from: { x: 0, y: 0 },
+            to: { x: 1, y: 0 },
+            text: testCase.text,
+            font: "tscircuit2024",
+            font_size: 0.5,
+            arrow_size: 0.4,
+            offset_distance: 0.5,
+            layer: "top",
+          } as never)
+        : ({
+            type: testCase.type,
+            text: testCase.text,
+            anchor_position: { x: 0, y: 0 },
+            anchor_alignment: "center",
+            layer: "top",
+            font: "tscircuit2024",
+            font_size: 1,
+          } as never),
+    ])
+    expect(footprint).toContain(testCase.expectedJsx)
+
+    if (!testCase.roundTrip) continue
+
+    const circuitJson = await runTscircuitCode(`
+      export default () => ${footprint}
+    `)
+    const element = circuitJson.find((item) => item.type === testCase.type) as
+      | { text?: string }
+      | undefined
+    expect(element?.text).toBe(testCase.text)
+  }
+})


### PR DESCRIPTION
Fixes #550.

`generateFootprintTsx` put `JSON.stringify` into quoted JSX attributes. That is invalid when the text contains `"`, and it HTML-decodes `&amp;` / `&#65;` instead of keeping the original characters.

Quoted attributes are kept for ordinary text (including `{NAME}`). Values that need JavaScript escaping or contain `&` are emitted as a JSX string expression, e.g. `text={"Connector 1/4\""}`.

Covered for silkscreen, fabrication-note, PCB-note, and dimension labels. Regression compiles the generated footprint with `runTscircuitCode` and checks the resulting `text` props.