### PR TITLE
fix: preserve bottom copper layers on imported SMT pads

### DIFF
--- a/lib/convert-easyeda-json-to-tscircuit-soup-json.ts
+++ b/lib/convert-easyeda-json-to-tscircuit-soup-json.ts
@@ -683,7 +683,7 @@ export const convertEasyEdaJsonToCircuitJson = (
               : {
                   radius: Math.min(mil2mm(pad.width), mil2mm(pad.height)) / 2,
                 }),
-        layer: "top",
+        layer: pad.layermask === 2 ? "bottom" : "top",
         port_hints: pcbPortHints,
         pcb_component_id: "pcb_component_1",
         pcb_port_id: `pcb_port_${index + 1}`,

--- a/lib/websafe/generate-footprint-tsx.ts
+++ b/lib/websafe/generate-footprint-tsx.ts
@@ -92,7 +92,7 @@ export const generateFootprintTsx = (
   for (const smtPad of smtPads) {
     if (smtPad.shape === "circle") {
       elementStrings.push(
-        `<smtpad portHints={${JSON.stringify(mapPortHints(smtPad.port_hints, options.portHintsMap))}} pcbX="${mmStr(smtPad.x)}" pcbY="${mmStr(smtPad.y)}" radius="${mmStr(smtPad.radius)}" shape="circle" />`,
+        `<smtpad portHints={${JSON.stringify(mapPortHints(smtPad.port_hints, options.portHintsMap))}} pcbX="${mmStr(smtPad.x)}" pcbY="${mmStr(smtPad.y)}" radius="${mmStr(smtPad.radius)}" shape="circle"${getLayerAttr(smtPad.layer)} />`,
       )
     } else if (smtPad.shape === "rect") {
       const cornerRadius =
@@ -102,18 +102,18 @@ export const generateFootprintTsx = (
           ? ` cornerRadius="${mmStr(cornerRadius)}"`
           : ""
       elementStrings.push(
-        `<smtpad portHints={${JSON.stringify(mapPortHints(smtPad.port_hints, options.portHintsMap))}} pcbX="${mmStr(smtPad.x)}" pcbY="${mmStr(smtPad.y)}" width="${mmStr(smtPad.width)}" height="${mmStr(smtPad.height)}"${cornerRadiusAttr} shape="rect" />`,
+        `<smtpad portHints={${JSON.stringify(mapPortHints(smtPad.port_hints, options.portHintsMap))}} pcbX="${mmStr(smtPad.x)}" pcbY="${mmStr(smtPad.y)}" width="${mmStr(smtPad.width)}" height="${mmStr(smtPad.height)}"${cornerRadiusAttr} shape="rect"${getLayerAttr(smtPad.layer)} />`,
       )
     } else if (smtPad.shape === "pill") {
       elementStrings.push(
-        `<smtpad portHints={${JSON.stringify(mapPortHints(smtPad.port_hints, options.portHintsMap))}} pcbX="${mmStr(smtPad.x)}" pcbY="${mmStr(smtPad.y)}" width="${mmStr(smtPad.width)}" height="${mmStr(smtPad.height)}" radius="${mmStr(smtPad.radius)}" shape="pill" />`,
+        `<smtpad portHints={${JSON.stringify(mapPortHints(smtPad.port_hints, options.portHintsMap))}} pcbX="${mmStr(smtPad.x)}" pcbY="${mmStr(smtPad.y)}" width="${mmStr(smtPad.width)}" height="${mmStr(smtPad.height)}" radius="${mmStr(smtPad.radius)}" shape="pill"${getLayerAttr(smtPad.layer)} />`,
       )
     } else if (smtPad.shape === "polygon") {
       const pointsStr = smtPad.points
         .map((p) => `{x: "${mmStr(p.x)}", y: "${mmStr(p.y)}"}`)
         .join(", ")
       elementStrings.push(
-        `<smtpad portHints={${JSON.stringify(mapPortHints(smtPad.port_hints, options.portHintsMap))}} points={[${pointsStr}]} shape="polygon" />`,
+        `<smtpad portHints={${JSON.stringify(mapPortHints(smtPad.port_hints, options.portHintsMap))}} points={[${pointsStr}]} shape="polygon"${getLayerAttr(smtPad.layer)} />`,
       )
     }
   }

--- a/tests/convert-to-soup-tests/smt-pad-layers.test.ts
+++ b/tests/convert-to-soup-tests/smt-pad-layers.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test"
+import { su } from "@tscircuit/circuit-json-util"
+import { convertEasyEdaJsonToCircuitJson } from "lib/convert-easyeda-json-to-tscircuit-soup-json"
+import { EasyEdaJsonSchema } from "lib/schemas/easy-eda-json-schema"
+import { generateFootprintTsx } from "lib/websafe/generate-footprint-tsx"
+import { runTscircuitCode } from "tscircuit"
+import referenceRawEasy from "../assets/C2848306.raweasy.json"
+
+const shapes = ["RECT", "ELLIPSE", "OVAL", "POLYGON"] as const
+
+const makeCircuit = (shape: (typeof shapes)[number]) => {
+  const rawEasy = structuredClone(referenceRawEasy)
+  rawEasy.dataStr.shape = []
+  // EasyEDA's format defines layer 1 as TopLayer and layer 2 as BottomLayer.
+  // This is synthetic pad geometry in an existing fixture's metadata envelope.
+  // https://docs.easyeda.com/en/DocumentFormat/3-EasyEDA-PCB-File-Format/#layers-config
+  rawEasy.packageDetail.dataStr.shape = [1, 2].map((layer) => {
+    const x = 400 + layer * 4
+    const points = `${x - 1} 299.5 ${x + 1} 299.5 ${x + 1} 300.5 ${x - 1} 300.5`
+    return `PAD~${shape}~${x}~300~2~1~${layer}~~${layer}~0~${points}~0~gge${layer}~0~~Y~0~0~0.2~${x},300`
+  })
+  return convertEasyEdaJsonToCircuitJson(EasyEdaJsonSchema.parse(rawEasy))
+}
+
+for (const shape of shapes) {
+  test(`preserves top and bottom copper when importing ${shape} SMT pads`, () => {
+    const pads = su(makeCircuit(shape)).pcb_smtpad.list()
+    expect(pads).toHaveLength(2)
+    expect(pads.map((pad) => pad.layer)).toEqual(["top", "bottom"])
+    expect(pads.map((pad) => pad.port_hints)).toEqual([["pin1"], ["pin2"]])
+  })
+
+  test(`preserves ${shape} pad layers through generated TSX execution`, async () => {
+    const pads = su(makeCircuit(shape)).pcb_smtpad.list()
+    // Establish the generator's input independently of the importer so this
+    // also catches layer loss in the second conversion stage.
+    pads[0].layer = "top"
+    pads[1].layer = "bottom"
+    const footprint = generateFootprintTsx(pads)
+    const result = await runTscircuitCode(`export default () => ${footprint}`)
+    expect(
+      su(result)
+        .pcb_smtpad.list()
+        .map((pad) => pad.layer),
+    ).toEqual(["top", "bottom"])
+  })
+}


### PR DESCRIPTION
An EasyEDA SMT pad on layer 2 (BottomLayer) currently becomes a top-layer pad in
Circuit JSON. The TSX footprint generator then also omits `layer` for every
supported SMT pad shape, so supplying correctly layered Circuit JSON still
produces top-side copper when the generated code is executed.

This change maps layer 2 to `bottom` during import and carries non-default pad
layers through generated TSX for rectangles, circles, pills and polygons. Top-side
output is unchanged. Through-hole handling is unchanged and its existing test passes.

The layer expectation comes from the [EasyEDA PCB file format](https://docs.easyeda.com/en/DocumentFormat/3-EasyEDA-PCB-File-Format/#layers-config),
which defines 1 as TopLayer and 2 as BottomLayer. Eight new cases exercise import
and generated TSX execution separately, with synthetic pad geometry inside an
existing fixture's metadata. All eight fail before the fix (bottom becomes top).

Validation on macOS, Bun 1.4.0:

- `bun test --timeout 60000`: 232 pass, 0 fail; 79 snapshots.
- `bunx tsc --noEmit`: pass.
- `bun run format:check`: pass.
- `bun run build`: pass.
- Published branch tree checked against the locally tested commit.

Prepared and tested with OpenAI Codex for @het392cor. This is software-level
verification; no fabricated board or physical hardware test is claimed.
