### PR TITLE
fix: reject invalid EasyEDA component detail responses

### DIFF
--- a/lib/websafe/fetch-easyeda-json.ts
+++ b/lib/websafe/fetch-easyeda-json.ts
@@ -1,6 +1,7 @@
 import type { RawEasyEdaJson } from "../schemas/easy-eda-json-schema"
 import { getModelCdnUrl } from "./get-model-cdn-url"
 import { parseEasyEdaSearchResponse } from "./parse-easyeda-search-response"
+import { parseEasyEdaComponentResponse } from "./parse-easyeda-component-response"
 
 type ModelBounds = {
   min: { x: number; y: number; z: number }
@@ -166,8 +167,10 @@ export async function fetchEasyEDAComponent(
     )
   }
 
-  const componentResult = await componentResponse.json()
-  const result = componentResult.result as RawEasyEdaJson
+  const result = parseEasyEdaComponentResponse(
+    await componentResponse.json(),
+    jlcpcbPartNumber,
+  )
 
   if (includeModelMetadata) {
     const modelUuid = getModelUuidFromRawPackageDetail(result)

--- a/lib/websafe/parse-easyeda-component-response.ts
+++ b/lib/websafe/parse-easyeda-component-response.ts
@@ -1,0 +1,40 @@
+import { z } from "zod"
+import type { RawEasyEdaJson } from "../schemas/easy-eda-json-schema"
+
+const componentEnvelopeSchema = z.object({
+  success: z.boolean(),
+  code: z.number().optional(),
+  message: z.string().optional(),
+})
+
+const componentResultSchema = z.object({
+  result: z.object({ uuid: z.string().min(1) }).passthrough(),
+})
+
+export const parseEasyEdaComponentResponse = (
+  response: unknown,
+  jlcpcbPartNumber: string,
+): RawEasyEdaJson => {
+  const envelope = componentEnvelopeSchema.safeParse(response)
+  if (!envelope.success) {
+    throw new Error(
+      `Invalid EasyEDA component response for "${jlcpcbPartNumber}": expected a boolean success field`,
+    )
+  }
+  if (!envelope.data.success) {
+    const { code, message } = envelope.data
+    throw new Error(
+      `EasyEDA API rejected the component details for "${jlcpcbPartNumber}"${code === undefined ? "" : ` (code ${code})`}${message ? `: ${message}` : ""}`,
+    )
+  }
+
+  const component = componentResultSchema.safeParse(response)
+  if (!component.success) {
+    throw new Error(
+      `Invalid EasyEDA component response for "${jlcpcbPartNumber}": expected a result object with a component UUID`,
+    )
+  }
+
+  // Keep raw geometry untouched; conversion performs full schema validation.
+  return component.data.result as RawEasyEdaJson
+}

--- a/tests/fetch-tests/invalid-component-response.test.ts
+++ b/tests/fetch-tests/invalid-component-response.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "bun:test"
+import { fetchEasyEDAComponent } from "lib/websafe/fetch-easyeda-json"
+import diode from "../assets/C8598.raweasy.json"
+
+const invalidResponses = [
+  { name: "null envelope", response: null },
+  { name: "empty envelope", response: {} },
+  { name: "string success", response: { success: "true", result: diode } },
+  { name: "missing result", response: { success: true } },
+  { name: "null result", response: { success: true, result: null } },
+  { name: "array result", response: { success: true, result: [] } },
+  { name: "string result", response: { success: true, result: "unavailable" } },
+  { name: "empty result", response: { success: true, result: {} } },
+  { name: "empty UUID", response: { success: true, result: { uuid: "" } } },
+  {
+    name: "API rejection",
+    response: { success: false, code: 404, message: "Component removed" },
+  },
+  { name: "rejection with data", response: { success: false, result: diode } },
+]
+
+for (const includeModelMetadata of [false, true]) {
+  test.each(invalidResponses)(
+    `rejects $name (metadata=${includeModelMetadata})`,
+    async ({ response }) => {
+      let requestCount = 0
+      const fetch = Object.assign(
+        async () => {
+          requestCount += 1
+          if (requestCount === 1) {
+            return Response.json({
+              success: true,
+              result: {
+                lists: {
+                  lcsc: [{ uuid: diode.uuid, lcsc: { number: "C8598" } }],
+                },
+              },
+            })
+          }
+          return Response.json(response)
+        },
+        { preconnect: globalThis.fetch.preconnect },
+      )
+
+      await expect(
+        fetchEasyEDAComponent("C8598", { fetch, includeModelMetadata }),
+      ).rejects.toThrow(/EasyEDA.*component.*C8598/i)
+      expect(requestCount).toBe(2)
+    },
+  )
+}


### PR DESCRIPTION
The component-details request currently checks HTTP status but ignores the JSON success flag. A response with `success: false` can return geometry as if it succeeded; a missing result returns `undefined` when model metadata is disabled or produces a `TypeError` when enabled.

This adds component-envelope validation before model metadata lookup, preserving the raw geometry for the existing conversion layer. Failures identify the requested part and include the API error code/message when available. The change follows the existing search-response validation pattern.

Validation:
- 18 initial offline regression cases failed on unmodified main (`06077ed`); expanded coverage now includes missing/empty UUIDs.
- 39 focused fetch tests pass, including 22 new cases covering both metadata settings, existing exact-match behavior, search errors and HTTP rate limiting.
- TypeScript `--noEmit`, formatting for the three changed files, `git diff --check`, and the library/browser/CLI build pass.
- Checked one public component-details response to confirm the `success`/`code`/`result` envelope. The malformed responses are injected regression cases, not a claim of a live API outage.
- Full image/network test suite not run.

Prepared and tested with OpenAI Codex assistance. No fixed bounty or payment is claimed for this contribution.
